### PR TITLE
fix: Hide Y overflow on settings page navigation

### DIFF
--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -42,7 +42,7 @@ export function SettingsPage() {
                 onValueChange={shell.setActiveSettingsTab}
                 className="flex min-h-0 flex-1 flex-col"
             >
-                <div className="max-w-full shrink-0 overflow-x-auto">
+                <div className="max-w-full shrink-0 overflow-x-auto overflow-y-hidden">
                     <TabsList>
                         {shell.settingsTabs.map(([value, labelKey]: any) => (
                             <TabsTrigger key={value} value={value}>


### PR DESCRIPTION
Tiny PR to fix the tiny, seemingly useless vertical scrolling on the settings tab list.

**Before:**
<img width="810" height="78" alt="image" src="https://github.com/user-attachments/assets/78b26212-1fc4-4fdb-80e8-219d585a2b20" />

**After:**
<img width="981" height="84" alt="image" src="https://github.com/user-attachments/assets/81d7ce65-56de-4b3d-b0e2-840596504537" />

