### PR TITLE
fix: status bar localization error

### DIFF
--- a/src/localization/ja.json
+++ b/src/localization/ja.json
@@ -5380,7 +5380,7 @@
         "clocks_label": "時計",
         "clocks_none": "なし",
         "timezone": "タイムゾーン",
-        "now_playing": "現在プレイ中",
+        "now_playing": "再生中",
         "instance_queue": "キュー",
         "instance_queue_waiting": "待機中",
         "instance_queue_position": "#{position}",

--- a/src/localization/zh-CN.json
+++ b/src/localization/zh-CN.json
@@ -5380,7 +5380,7 @@
         "clocks_label": "时钟",
         "clocks_none": "无",
         "timezone": "时区",
-        "now_playing": "正在游玩",
+        "now_playing": "正在播放",
         "instance_queue": "排队",
         "instance_queue_waiting": "等待中",
         "instance_queue_position": "第 {position} 位",

--- a/src/localization/zh-TW.json
+++ b/src/localization/zh-TW.json
@@ -5380,7 +5380,7 @@
         "clocks_label": "時鐘",
         "clocks_none": "無",
         "timezone": "時區",
-        "now_playing": "正在游玩",
+        "now_playing": "正在播放",
         "instance_queue": "排隊",
         "instance_queue_waiting": "等待中",
         "instance_queue_position": "第 {position} 位",


### PR DESCRIPTION
Here, `now-playing` refers to videos or media playing within the game, so it should be translated according to this definition. 
<img width="372" height="80" alt="image" src="https://github.com/user-attachments/assets/0aef2e12-53d8-4f19-a959-5cf3d4a35d02" />
