### PR TITLE
refa(web_client): use dirty flag instead of strings difference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "as-slice"
@@ -3011,9 +3011,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loop9"
@@ -3088,9 +3088,9 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -4116,9 +4116,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4136,9 +4136,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -4172,9 +4172,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -4467,18 +4467,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest_cookie_store"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb98c4d52ae6ceed18a0dff0564717623dd75fae08619ae0927332f0a81abbc"
-dependencies = [
- "bytes",
- "cookie_store",
- "reqwest",
- "url",
-]
-
-[[package]]
 name = "rfd"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4627,9 +4615,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5447,9 +5435,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.3"
+version = "0.39.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
+checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
 dependencies = [
  "libc",
  "memchr",
@@ -6087,9 +6075,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "num-conv",
@@ -6107,9 +6095,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6952,9 +6940,9 @@ name = "vrcx-0-vrchat-client"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "cookie_store",
  "percent-encoding",
  "reqwest",
- "reqwest_cookie_store",
  "serde",
  "serde_json",
  "specta",

--- a/crates/application/src/web_client.rs
+++ b/crates/application/src/web_client.rs
@@ -33,19 +33,17 @@ impl WebClient {
     }
 
     pub fn save_cookies(&self, db: &DatabaseService) {
-        if let Some(maybe_b64) = self
-            .inner
-            .cookie_jar()
-            .with_snapshot_if_dirty(transport::serialize_cookie_store, true)
-        {
-            let b64 = match maybe_b64 {
-                Some(b64) => b64,
-                None => return,
-            };
-            if let Err(error) = cookies::save_default_cookies(db, &b64) {
-                tracing::warn!("failed to persist cookies: {error}");
-                return;
-            }
+        let jar = self.inner.cookie_jar();
+        let Some(maybe_b64) = jar.flush_if_dirty(transport::serialize_cookie_store) else {
+            return;
+        };
+        let Some(b64) = maybe_b64 else {
+            jar.mark_dirty();
+            return;
+        };
+        if let Err(error) = cookies::save_default_cookies(db, &b64) {
+            jar.mark_dirty();
+            tracing::warn!("failed to persist cookies: {error}");
         }
     }
 

--- a/crates/application/src/web_client.rs
+++ b/crates/application/src/web_client.rs
@@ -1,5 +1,3 @@
-use std::sync::Mutex;
-
 use vrcx_0_integrations::external_api::{
     self, ExternalApiExecuteResponse, ExternalApiScope, ExternalHttpRequestInput,
     ExternalWebExecuteRequest,
@@ -17,7 +15,6 @@ use crate::Result;
 pub struct WebClient {
     inner: transport::WebClient,
     realtime_origin: String,
-    last_saved_cookies: Mutex<Option<String>>,
 }
 
 impl WebClient {
@@ -32,21 +29,24 @@ impl WebClient {
         Ok(Self {
             inner,
             realtime_origin,
-            last_saved_cookies: Mutex::new(persisted_cookies),
         })
     }
 
     pub fn save_cookies(&self, db: &DatabaseService) {
-        let b64 = self.inner.get_cookies();
-        let mut last_saved = self.last_saved_cookies.lock().unwrap();
-        if last_saved.as_ref() == Some(&b64) {
-            return;
+        if let Some(maybe_b64) = self
+            .inner
+            .cookie_jar()
+            .with_snapshot_if_dirty(transport::serialize_cookie_store, true)
+        {
+            let b64 = match maybe_b64 {
+                Some(b64) => b64,
+                None => return,
+            };
+            if let Err(error) = cookies::save_default_cookies(db, &b64) {
+                tracing::warn!("failed to persist cookies: {error}");
+                return;
+            }
         }
-        if let Err(error) = cookies::save_default_cookies(db, &b64) {
-            tracing::warn!("failed to persist cookies: {error}");
-            return;
-        }
-        *last_saved = Some(b64);
     }
 
     pub fn proxy_url(&self) -> Option<&str> {

--- a/crates/vrchat-client/Cargo.toml
+++ b/crates/vrchat-client/Cargo.toml
@@ -14,7 +14,6 @@ reqwest = { workspace = true, features = [
     "multipart",
     "socks"
 ] }
-reqwest_cookie_store = "0.10"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 specta.workspace = true
@@ -23,3 +22,4 @@ tokio = { workspace = true, features = ["net", "io-util"] }
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
 url = { workspace = true }
 vrcx-0-core = { path = "../core" }
+cookie_store = "0.22.1"

--- a/crates/vrchat-client/src/cookies.rs
+++ b/crates/vrchat-client/src/cookies.rs
@@ -1,0 +1,141 @@
+// Modified from https://github.com/pfernie/reqwest_cookie_store/blob/c906d634bad35b9f79abdc36f939979e39d1a2e1/src/lib.rs
+// Original code licensed under MIT
+
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use cookie_store::{Cookie, CookieStore, RawCookie, RawCookieParseError};
+use reqwest::header::HeaderValue;
+use tokio_tungstenite::tungstenite::Bytes;
+use url::Url;
+
+pub struct CookieJarInner {
+    dirty: bool,
+    store: CookieStore,
+}
+
+pub struct CookieJar(std::sync::Mutex<CookieJarInner>);
+
+impl CookieJar {
+    pub fn new(store: CookieStore) -> Self {
+        Self(std::sync::Mutex::new(CookieJarInner {
+            dirty: false,
+            store,
+        }))
+    }
+
+    pub fn has_changed(&self) -> bool {
+        self.0.lock().unwrap().dirty
+    }
+
+    pub fn with_snapshot_if_dirty<F, R>(&self, closure: F, is_flush: bool) -> Option<R>
+    where
+        F: FnOnce(&CookieStore) -> R,
+    {
+        self.map(|inner| {
+            inner.dirty.then(|| {
+                if is_flush {
+                    inner.dirty = false;
+                }
+                closure(&inner.store)
+            })
+        })
+    }
+
+    pub fn read_with<F, R>(&self, closure: F) -> R
+    where
+        F: FnOnce(&CookieStore) -> R,
+    {
+        self.map(|inner| closure(&inner.store))
+    }
+
+    pub fn update<F, R>(&self, closure: F) -> R
+    where
+        F: FnOnce(&mut CookieStore) -> R,
+    {
+        self.map(|inner| {
+            inner.dirty = true;
+            closure(&mut inner.store)
+        })
+    }
+
+    pub fn map<F, R>(&self, closure: F) -> R
+    where
+        F: FnOnce(&mut CookieJarInner) -> R,
+    {
+        let mut guard = self.0.lock().unwrap();
+        closure(&mut guard)
+    }
+
+    pub fn into_inner(self) -> (bool, CookieStore) {
+        let inner = self.0.into_inner().unwrap();
+        (inner.dirty, inner.store)
+    }
+}
+
+impl reqwest::cookie::CookieStore for CookieJar {
+    fn set_cookies(&self, cookie_headers: &mut dyn Iterator<Item = &HeaderValue>, url: &Url) {
+        let mut guard = self.0.lock().unwrap();
+        guard.dirty = true;
+        set_cookies(&mut guard.store, cookie_headers, url);
+    }
+
+    fn cookies(&self, url: &Url) -> Option<HeaderValue> {
+        let guard = self.0.lock().unwrap();
+        let s = guard
+            .store
+            .get_request_values(url)
+            .map(|(name, value)| format!("{}={}", name, value))
+            .collect::<Vec<_>>()
+            .join("; ");
+
+        if s.is_empty() {
+            return None;
+        }
+
+        HeaderValue::from_maybe_shared(Bytes::from(s)).ok()
+    }
+}
+
+fn set_cookies(
+    cookie_store: &mut CookieStore,
+    cookie_headers: &mut dyn Iterator<Item = &HeaderValue>,
+    url: &Url,
+) {
+    let cookies = cookie_headers.filter_map(|val| {
+        std::str::from_utf8(val.as_bytes())
+            .map_err(RawCookieParseError::from)
+            .and_then(RawCookie::parse)
+            .map(|c| c.into_owned())
+            .ok()
+    });
+    cookie_store.store_response_cookies(cookies, url);
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+#[serde(rename_all = "PascalCase")]
+pub struct CookieEntry {
+    pub name: String,
+    pub value: String,
+    pub domain: String,
+    pub path: String,
+}
+
+pub fn serialize_cookie_store(store: &CookieStore) -> Option<String> {
+    let mut json = Vec::new();
+    #[allow(deprecated)]
+    store
+        .save_incl_expired_and_nonpersistent_json(&mut json)
+        .ok()?;
+    Some(B64.encode(json))
+}
+
+pub fn deserialize_cookie_store(b64: &str) -> Option<CookieStore> {
+    let bytes = B64.decode(b64).ok()?;
+    #[allow(deprecated)]
+    CookieStore::load_json_all(&*bytes).ok()
+}
+
+pub fn deserialize_legacy_cookie_entries(b64: &str) -> Option<Vec<CookieEntry>> {
+    let bytes = B64.decode(b64).ok()?;
+    serde_json::from_slice::<Vec<CookieEntry>>(&bytes).ok()
+}

--- a/crates/vrchat-client/src/cookies.rs
+++ b/crates/vrchat-client/src/cookies.rs
@@ -3,9 +3,8 @@
 
 use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine;
-use cookie_store::{Cookie, CookieStore, RawCookie, RawCookieParseError};
+use cookie_store::{CookieStore, RawCookie, RawCookieParseError};
 use reqwest::header::HeaderValue;
-use tokio_tungstenite::tungstenite::Bytes;
 use url::Url;
 
 pub struct CookieJarInner {
@@ -23,19 +22,21 @@ impl CookieJar {
         }))
     }
 
-    pub fn has_changed(&self) -> bool {
-        self.0.lock().unwrap().dirty
+    pub fn mark_dirty(&self) {
+        self.map(|inner| inner.dirty = true);
     }
 
-    pub fn with_snapshot_if_dirty<F, R>(&self, closure: F, is_flush: bool) -> Option<R>
+    pub fn clear_dirty(&self) {
+        self.map(|inner| inner.dirty = false);
+    }
+
+    pub fn flush_if_dirty<F, R>(&self, closure: F) -> Option<R>
     where
         F: FnOnce(&CookieStore) -> R,
     {
         self.map(|inner| {
             inner.dirty.then(|| {
-                if is_flush {
-                    inner.dirty = false;
-                }
+                inner.dirty = false;
                 closure(&inner.store)
             })
         })
@@ -65,11 +66,6 @@ impl CookieJar {
         let mut guard = self.0.lock().unwrap();
         closure(&mut guard)
     }
-
-    pub fn into_inner(self) -> (bool, CookieStore) {
-        let inner = self.0.into_inner().unwrap();
-        (inner.dirty, inner.store)
-    }
 }
 
 impl reqwest::cookie::CookieStore for CookieJar {
@@ -92,7 +88,7 @@ impl reqwest::cookie::CookieStore for CookieJar {
             return None;
         }
 
-        HeaderValue::from_maybe_shared(Bytes::from(s)).ok()
+        HeaderValue::try_from(s).ok()
     }
 }
 
@@ -138,4 +134,40 @@ pub fn deserialize_cookie_store(b64: &str) -> Option<CookieStore> {
 pub fn deserialize_legacy_cookie_entries(b64: &str) -> Option<Vec<CookieEntry>> {
     let bytes = B64.decode(b64).ok()?;
     serde_json::from_slice::<Vec<CookieEntry>>(&bytes).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_jar_is_clean() {
+        let jar = CookieJar::new(CookieStore::default());
+        assert!(jar.flush_if_dirty(|_| ()).is_none());
+    }
+
+    #[test]
+    fn update_marks_dirty_and_flush_clears_once() {
+        let jar = CookieJar::new(CookieStore::default());
+        jar.update(|_| {});
+        assert!(jar.flush_if_dirty(|_| ()).is_some());
+        assert!(jar.flush_if_dirty(|_| ()).is_none());
+    }
+
+    #[test]
+    fn mark_dirty_rearms_after_flush() {
+        let jar = CookieJar::new(CookieStore::default());
+        jar.update(|_| {});
+        assert!(jar.flush_if_dirty(|_| ()).is_some());
+        jar.mark_dirty();
+        assert!(jar.flush_if_dirty(|_| ()).is_some());
+    }
+
+    #[test]
+    fn clear_dirty_suppresses_next_flush() {
+        let jar = CookieJar::new(CookieStore::default());
+        jar.update(|_| {});
+        jar.clear_dirty();
+        assert!(jar.flush_if_dirty(|_| ()).is_none());
+    }
 }

--- a/crates/vrchat-client/src/image_fetcher.rs
+++ b/crates/vrchat-client/src/image_fetcher.rs
@@ -1,8 +1,8 @@
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
+use crate::cookies::CookieJar;
 use reqwest::Client;
-use reqwest_cookie_store::CookieStoreMutex;
 
 pub type Result<T> = std::result::Result<T, ImageFetchError>;
 
@@ -18,7 +18,7 @@ pub struct ImageFetcher {
 }
 
 impl ImageFetcher {
-    pub fn new(cookie_jar: Arc<CookieStoreMutex>, proxy_url: Option<&str>) -> Result<Self> {
+    pub fn new(cookie_jar: Arc<CookieJar>, proxy_url: Option<&str>) -> Result<Self> {
         let mut builder = Client::builder()
             .cookie_provider(cookie_jar)
             .user_agent("VRCX-0");

--- a/crates/vrchat-client/src/lib.rs
+++ b/crates/vrchat-client/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod avatars;
+pub mod cookies;
 pub mod favorites;
 pub mod friends;
 pub mod groups;

--- a/crates/vrchat-client/src/web_client.rs
+++ b/crates/vrchat-client/src/web_client.rs
@@ -99,12 +99,20 @@ fn load_cookie_store(bytes: &[u8]) -> Result<CookieStore> {
 }
 
 fn validate_cookie_store_domains(store: &CookieStore) -> Result<()> {
+    let mut saw_domain = false;
     for domain in store.iter_any().filter_map(|cookie| cookie.domain.as_cow()) {
+        saw_domain = true;
         if !is_vrchat_cookie_domain(&domain) {
             return Err(Error::Custom(format!(
                 "cookie domain is not allowed: {domain}"
             )));
         }
+    }
+
+    if !saw_domain {
+        return Err(Error::Custom(
+            "cookie payload does not contain any cookie domains".into(),
+        ));
     }
 
     Ok(())
@@ -213,6 +221,7 @@ impl WebClient {
 
         if let Some(cookies_b64) = cookies_b64 {
             let _ = wc.restore_cookies(cookies_b64);
+            wc.jar.clear_dirty();
         }
 
         Ok(wc)
@@ -563,5 +572,20 @@ mod tests {
         }]));
 
         assert!(validate_vrchat_cookies_b64(&payload).is_err());
+    }
+
+    #[test]
+    fn rejects_cookie_store_without_domains() {
+        let store = CookieStore::default();
+        assert!(validate_cookie_store_domains(&store).is_err());
+    }
+
+    #[test]
+    fn accepts_cookie_store_with_vrchat_domain() {
+        let mut store = CookieStore::default();
+        let url = reqwest::Url::parse("https://vrchat.com/").unwrap();
+        let cookie = RawCookie::parse("auth=token; Domain=vrchat.com; Path=/").unwrap();
+        store.insert_raw(&cookie, &url).unwrap();
+        assert!(validate_cookie_store_domains(&store).is_ok());
     }
 }

--- a/crates/vrchat-client/src/web_client.rs
+++ b/crates/vrchat-client/src/web_client.rs
@@ -3,10 +3,10 @@ use std::io::Cursor;
 use std::sync::Arc;
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine};
+use cookie_store::{CookieStore, RawCookie};
 use reqwest::header::{HeaderName, HeaderValue, CONTENT_TYPE, REFERER};
 use reqwest::multipart::{Form, Part};
 use reqwest::{Client, Method, Proxy};
-use reqwest_cookie_store::{CookieStore, CookieStoreMutex, RawCookie};
 
 pub type Result<T> = std::result::Result<T, WebClientError>;
 
@@ -18,7 +18,12 @@ pub enum WebClientError {
     Io(#[from] std::io::Error),
 }
 
+use crate::cookies::{CookieEntry, CookieJar};
 use WebClientError as Error;
+
+pub use crate::cookies::{
+    deserialize_cookie_store, deserialize_legacy_cookie_entries, serialize_cookie_store,
+};
 
 #[derive(Clone, Debug, Default)]
 pub enum WebUploadMode {
@@ -64,15 +69,6 @@ impl WebExecuteRequest {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, specta::Type)]
-#[serde(rename_all = "PascalCase")]
-struct CookieEntry {
-    name: String,
-    value: String,
-    domain: String,
-    path: String,
-}
-
 pub fn validate_vrchat_cookies_b64(b64: &str) -> Result<()> {
     const MAX_COOKIE_STORE_BYTES: usize = 1024 * 1024;
 
@@ -103,17 +99,7 @@ fn load_cookie_store(bytes: &[u8]) -> Result<CookieStore> {
 }
 
 fn validate_cookie_store_domains(store: &CookieStore) -> Result<()> {
-    let domains = store
-        .iter_any()
-        .filter_map(|cookie| cookie.domain.as_cow().map(|domain| domain.to_string()))
-        .collect::<Vec<_>>();
-    if domains.is_empty() {
-        return Err(Error::Custom(
-            "cookie payload does not contain any cookie domains".into(),
-        ));
-    }
-
-    for domain in domains {
+    for domain in store.iter_any().filter_map(|cookie| cookie.domain.as_cow()) {
         if !is_vrchat_cookie_domain(&domain) {
             return Err(Error::Custom(format!(
                 "cookie domain is not allowed: {domain}"
@@ -191,14 +177,14 @@ fn is_vrchat_cookie_domain(domain: &str) -> bool {
 
 pub struct WebClient {
     client: Client,
-    jar: Arc<CookieStoreMutex>,
+    jar: Arc<CookieJar>,
     proxy_url: Option<String>,
 }
 
 impl WebClient {
     pub fn new(proxy_url: Option<String>, cookies_b64: Option<&str>) -> Result<Self> {
-        let cookie_store = reqwest_cookie_store::CookieStore::default();
-        let jar = Arc::new(CookieStoreMutex::new(cookie_store));
+        let cookie_store = CookieStore::default();
+        let jar = Arc::new(CookieJar::new(cookie_store));
 
         let mut builder = Client::builder()
             .cookie_provider(jar.clone())
@@ -233,52 +219,35 @@ impl WebClient {
     }
 
     fn restore_cookies(&self, b64: &str) -> Result<bool> {
-        if let Some(store) = Self::deserialize_cookie_store(b64) {
-            let mut jar = self.jar.lock().unwrap();
-            *jar = store;
+        if let Some(new_store) = crate::cookies::deserialize_cookie_store(b64) {
+            self.jar.update(|store_mut| *store_mut = new_store);
             return Ok(true);
         }
-        if let Some(entries) = Self::deserialize_legacy_cookie_entries(b64) {
+        if let Some(entries) = crate::cookies::deserialize_legacy_cookie_entries(b64) {
             self.apply_cookie_entries(&entries)?;
             return Ok(true);
         }
         Ok(false)
     }
 
-    fn serialize_cookie_store(&self) -> Option<String> {
-        let store = self.jar.lock().unwrap();
-        let mut json = Vec::new();
-        #[allow(deprecated)]
-        store
-            .save_incl_expired_and_nonpersistent_json(&mut json)
-            .ok()?;
-        Some(B64.encode(json))
-    }
-
-    fn deserialize_cookie_store(b64: &str) -> Option<CookieStore> {
-        let bytes = B64.decode(b64).ok()?;
-        #[allow(deprecated)]
-        CookieStore::load_json_all(Cursor::new(bytes)).ok()
-    }
-
-    fn deserialize_legacy_cookie_entries(b64: &str) -> Option<Vec<CookieEntry>> {
-        let bytes = B64.decode(b64).ok()?;
-        serde_json::from_slice::<Vec<CookieEntry>>(&bytes).ok()
+    fn cookies_snapshot_b64(&self) -> Option<String> {
+        self.jar.read_with(crate::cookies::serialize_cookie_store)
     }
 
     fn apply_cookie_entries(&self, entries: &[CookieEntry]) -> Result<()> {
-        let mut store = self.jar.lock().unwrap();
-        for e in entries {
-            let url = legacy_cookie_url(e)?;
-            let cookie = legacy_raw_cookie(e)?;
-            store
-                .insert_raw(&cookie, &url)
-                .map_err(|error| Error::Custom(format!("insert legacy cookie: {error}")))?;
-        }
-        Ok(())
+        self.jar.update(|store| {
+            for e in entries {
+                let url = legacy_cookie_url(e)?;
+                let cookie = legacy_raw_cookie(e)?;
+                store
+                    .insert_raw(&cookie, &url)
+                    .map_err(|error| Error::Custom(format!("insert legacy cookie: {error}")))?;
+            }
+            Ok(())
+        })
     }
 
-    pub fn cookie_jar(&self) -> Arc<CookieStoreMutex> {
+    pub fn cookie_jar(&self) -> Arc<CookieJar> {
         self.jar.clone()
     }
 
@@ -287,12 +256,11 @@ impl WebClient {
     }
 
     pub fn clear_cookies(&self) {
-        let mut store = self.jar.lock().unwrap();
-        store.clear();
+        self.jar.update(|store| store.clear());
     }
 
     pub fn get_cookies(&self) -> String {
-        self.serialize_cookie_store().unwrap_or_default()
+        self.cookies_snapshot_b64().unwrap_or_default()
     }
 
     pub fn set_cookies(&self, b64: &str) -> Result<()> {


### PR DESCRIPTION
Remove `last_saved_cookies`.  

Instead of comparing new cookies b64 against `last_saved_cookies`, use a `CookieJar` that marks itself dirty when updated, saving cookies only when dirty.

dirty flag set when cookies received
<img width="957" height="199" alt="file-cf10973b6fdb8770da1167a852d4ce21" src="https://github.com/user-attachments/assets/4f96695d-57c4-4918-9686-83e0fddbb3be" />

cookies persistence only when dirty
<img width="674" height="396" alt="image" src="https://github.com/user-attachments/assets/72b56a22-3a6e-4c99-bb68-883185c17dea" />
