### PR TITLE
feat: Add world/user links and instance details to Discord webhook.

### DIFF
--- a/crates/runtime-host/src/notification/dispatcher.rs
+++ b/crates/runtime-host/src/notification/dispatcher.rs
@@ -20,7 +20,9 @@ use vrcx_0_vrchat_client::http_api::ApiScope;
 use vrcx_0_vrchat_client::web_client::WebExecuteRequest;
 
 use crate::notification::user_image::UserImageCache;
-use crate::vr_overlay::{discord_has_rich_title, OverlayLocale, OverlayLocalizer};
+use crate::vr_overlay::{
+    discord_embed_kind, discord_title_key, DiscordEmbedKind, OverlayLocale, OverlayLocalizer,
+};
 
 const APP_LANGUAGE_CONFIG_KEY: &str = "appLanguage";
 const WEBHOOK_TIMEOUT: Duration = Duration::from_secs(10);
@@ -996,7 +998,7 @@ fn discord_webhook_payload(
     locale: OverlayLocale,
 ) -> Value {
     let entry = &delivery.entry;
-    if !discord_has_rich_title(&entry.activity_type) {
+    if discord_title_key(&entry.activity_type).is_none() {
         return discord_legacy_embed(delivery, render);
     }
     let localizer = OverlayLocalizer::new(locale);
@@ -1008,40 +1010,41 @@ fn discord_webhook_payload(
     }
 
     let mut description = String::new();
-    let is_invite = matches!(
-        entry.activity_type.as_str(),
-        "invite" | "requestInvite" | "inviteResponse" | "requestInviteResponse"
-    );
-    if is_invite {
-        let message = entry.content.detail.trim();
-        if !message.is_empty() && message != render.display_location.trim() {
-            description.push_str(&format!("\u{300c}{message}\u{300d}"));
+    match discord_embed_kind(&entry.activity_type) {
+        DiscordEmbedKind::Invite => {
+            let message = entry.content.detail.trim();
+            if !message.is_empty() && message != render.display_location.trim() {
+                description.push_str(&format!("\u{300c}{message}\u{300d}"));
+            }
         }
-    }
-    if entry.activity_type == "GPS" {
-        let content = &entry.content;
-        let target = if !content.world_name.trim().is_empty() {
-            content.world_name.trim()
-        } else if !render.display_location.trim().is_empty() {
-            render.display_location.trim()
-        } else if !render.body.trim().is_empty() {
-            render.body.trim()
-        } else {
-            render.text.trim()
-        };
-        if !target.is_empty() {
-            description.push_str(&format!("\u{2192} {target}"));
+        DiscordEmbedKind::Gps => {
+            let content = &entry.content;
+            let target = if !content.world_name.trim().is_empty() {
+                content.world_name.trim()
+            } else if !render.display_location.trim().is_empty() {
+                render.display_location.trim()
+            } else if !render.body.trim().is_empty() {
+                render.body.trim()
+            } else {
+                render.text.trim()
+            };
+            if !target.is_empty() {
+                description.push_str(&format!("\u{2192} {target}"));
+            }
         }
-    } else if entry.activity_type == "Status" {
-        let status = localizer.status_text(&entry.content.status);
-        if !status.is_empty() {
-            description.push_str(&status);
+        DiscordEmbedKind::Status => {
+            let status = localizer.status_text(&entry.content.status);
+            if !status.is_empty() {
+                description.push_str(&status);
+            }
         }
-    } else if entry.activity_type == "AvatarChange" {
-        let avatar = entry.content.avatar_name.trim();
-        if !avatar.is_empty() {
-            description.push_str(avatar);
+        DiscordEmbedKind::AvatarChange => {
+            let avatar = entry.content.avatar_name.trim();
+            if !avatar.is_empty() {
+                description.push_str(avatar);
+            }
         }
+        DiscordEmbedKind::Other => {}
     }
 
     let author = build_discord_author(entry, render);

--- a/crates/runtime-host/src/notification/dispatcher.rs
+++ b/crates/runtime-host/src/notification/dispatcher.rs
@@ -7,14 +7,20 @@ use vrcx_0_application::{
     OverlayActivitySnapshot, RuntimeDiagnostics, RuntimeEventBus, TaskSupervisor, WebClient,
     WorldCache,
 };
-use vrcx_0_core::location::{format_display_location, is_meaningful_world_name, parse_location};
+use vrcx_0_core::location::{
+    format_display_location, is_meaningful_world_name, parse_location, ParsedLocation,
+};
+use vrcx_0_core::vrchat_endpoints::VRCHAT_SITE_ORIGIN;
 use vrcx_0_host::overlay_notifications::{send_xs_notification, OvrToolkit};
 use vrcx_0_persistence::config::ConfigRepository;
+use vrcx_0_persistence::worlds::world_cache_get;
 use vrcx_0_persistence::DatabaseService;
+use vrcx_0_vrchat_client::avatars::avatar_file_get_input;
+use vrcx_0_vrchat_client::http_api::ApiScope;
 use vrcx_0_vrchat_client::web_client::WebExecuteRequest;
 
 use crate::notification::user_image::UserImageCache;
-use crate::vr_overlay::{OverlayLocale, OverlayLocalizer};
+use crate::vr_overlay::{discord_has_rich_title, OverlayLocale, OverlayLocalizer};
 
 const APP_LANGUAGE_CONFIG_KEY: &str = "appLanguage";
 const WEBHOOK_TIMEOUT: Duration = Duration::from_secs(10);
@@ -274,12 +280,39 @@ impl OverlayActivitySink for NotificationDispatcher {
                 )
                 .await;
             }
-            let render = render_delivery(&delivery, locale);
+            let is_discord = plan.webhook && preferences.webhook_format == "discord";
+            if is_discord {
+                resolve_delivery_avatar_name(web.as_ref(), db.as_ref(), &endpoint, &mut delivery)
+                    .await;
+            }
+            let mut render = render_delivery(&delivery, locale);
+            if is_discord {
+                let (actor_image_url, world_image_url) = tokio::join!(
+                    resolve_actor_icon_url(
+                        user_image_cache.as_ref(),
+                        web.as_ref(),
+                        db.as_ref(),
+                        &endpoint,
+                        allow_user_icon,
+                        &delivery,
+                    ),
+                    resolve_world_thumbnail_url(
+                        world_cache.as_ref(),
+                        db.as_ref(),
+                        web.as_ref(),
+                        &endpoint,
+                        &delivery,
+                    ),
+                );
+                render.actor_image_url = actor_image_url;
+                render.world_image_url = world_image_url;
+            }
             dispatch_rendered_notification(
                 delivery,
                 preferences,
                 plan,
                 render,
+                locale,
                 image_cache,
                 ovrt,
                 web,
@@ -298,6 +331,7 @@ async fn dispatch_rendered_notification(
     preferences: NotificationDeliveryPreferences,
     plan: NotificationDeliveryPlan,
     render: RenderedNotification,
+    locale: OverlayLocale,
     image_cache: Arc<ImageCache>,
     ovrt: Arc<OvrToolkit>,
     web: Arc<WebClient>,
@@ -355,7 +389,7 @@ async fn dispatch_rendered_notification(
     }
 
     if plan.webhook {
-        send_webhook_with_retry(&web, &diagnostics, &delivery, &render, &preferences).await;
+        send_webhook_with_retry(&web, &diagnostics, &delivery, &render, &preferences, locale).await;
     }
 }
 
@@ -366,6 +400,8 @@ struct RenderedNotification {
     text: String,
     display_location: String,
     image_url: String,
+    actor_image_url: String,
+    world_image_url: String,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -469,6 +505,110 @@ fn delivery_actor_image_user_id<'a>(
     Some(actor_user_id)
 }
 
+async fn resolve_delivery_avatar_name(
+    web: &WebClient,
+    db: &DatabaseService,
+    endpoint: &str,
+    delivery: &mut OverlayActivityDelivery,
+) {
+    if delivery.entry.activity_type != "AvatarChange" {
+        return;
+    }
+    if !delivery.entry.content.avatar_name.trim().is_empty() {
+        return;
+    }
+    let Some(file_id) = extract_file_id(&delivery.entry.content.image_url) else {
+        return;
+    };
+    let Ok((_, request)) = avatar_file_get_input(endpoint.to_string(), file_id) else {
+        return;
+    };
+    let response = match tokio::time::timeout(
+        WEBHOOK_TIMEOUT,
+        web.execute_api(request, ApiScope::Vrchat, db),
+    )
+    .await
+    {
+        Ok(Ok(response)) => response,
+        _ => return,
+    };
+    if !(200..=299).contains(&response.status) {
+        return;
+    }
+    let Ok(value) = serde_json::from_str::<Value>(&response.data) else {
+        return;
+    };
+    if let Some(file_name) = value.get("name").and_then(Value::as_str) {
+        if let Some(name) = avatar_name_from_file_name(file_name) {
+            delivery.entry.content.avatar_name = name;
+        }
+    }
+}
+
+fn avatar_name_from_file_name(file_name: &str) -> Option<String> {
+    let lower = file_name.to_ascii_lowercase();
+    let start = lower.find("avatar - ")? + "avatar - ".len();
+    let end = lower.rfind(" - image -")?;
+    if end < start {
+        return None;
+    }
+    let name = file_name[start..end].trim();
+    (!name.is_empty()).then(|| name.to_string())
+}
+
+async fn resolve_actor_icon_url(
+    user_image_cache: &UserImageCache,
+    web: &WebClient,
+    db: &DatabaseService,
+    endpoint: &str,
+    allow_user_icon: bool,
+    delivery: &OverlayActivityDelivery,
+) -> String {
+    let actor = delivery.entry.actor_user_id.trim();
+    if actor.is_empty() {
+        return String::new();
+    }
+    user_image_cache
+        .resolve(web, db, endpoint, actor, allow_user_icon)
+        .await
+        .unwrap_or_default()
+}
+
+async fn resolve_world_thumbnail_url(
+    world_cache: &WorldCache,
+    db: &DatabaseService,
+    web: &WebClient,
+    endpoint: &str,
+    delivery: &OverlayActivityDelivery,
+) -> String {
+    let content = &delivery.entry.content;
+    let explicit = content.world_id.trim();
+    let world_id = if explicit.is_empty() {
+        parse_location(&content.location).world_id
+    } else {
+        explicit.to_string()
+    };
+    if world_id.is_empty() {
+        return String::new();
+    }
+    let _ = world_cache.resolve_name(web, endpoint, &world_id).await;
+    match world_cache_get(db, world_id.clone()) {
+        Ok(Some(world)) => {
+            let thumbnail = world.thumbnail_image_url.trim();
+            if thumbnail.is_empty() {
+                world.image_url.trim().to_string()
+            } else {
+                thumbnail.to_string()
+            }
+        }
+        Ok(None) => String::new(),
+        Err(error) => {
+            tracing::warn!(world_id = %world_id, "world thumbnail lookup failed: {error}");
+            String::new()
+        }
+    }
+}
+
 fn render_delivery(
     delivery: &OverlayActivityDelivery,
     locale: OverlayLocale,
@@ -499,6 +639,8 @@ fn render_delivery(
         text,
         display_location,
         image_url: entry.content.image_url.clone(),
+        actor_image_url: String::new(),
+        world_image_url: String::new(),
     }
 }
 
@@ -704,6 +846,7 @@ async fn send_webhook_with_retry(
     delivery: &OverlayActivityDelivery,
     render: &RenderedNotification,
     preferences: &NotificationDeliveryPreferences,
+    locale: OverlayLocale,
 ) {
     let url = preferences.webhook_url.trim();
     if url.is_empty() {
@@ -714,6 +857,7 @@ async fn send_webhook_with_retry(
         render,
         &preferences.webhook_format,
         &preferences.webhook_fields,
+        locale,
     );
     let body = match serde_json::to_string(&payload) {
         Ok(body) => body,
@@ -774,9 +918,10 @@ fn webhook_payload(
     render: &RenderedNotification,
     format: &str,
     fields: &[String],
+    locale: OverlayLocale,
 ) -> Value {
     if format == "discord" {
-        return discord_webhook_payload(delivery, render);
+        return discord_webhook_payload(delivery, render, locale);
     }
     let entry = &delivery.entry;
     let payload = json!({
@@ -848,31 +993,201 @@ pub fn webhook_local_time_string(created_at: &str) -> String {
 fn discord_webhook_payload(
     delivery: &OverlayActivityDelivery,
     render: &RenderedNotification,
+    locale: OverlayLocale,
 ) -> Value {
     let entry = &delivery.entry;
-    let description = if !render.display_location.trim().is_empty() {
+    if !discord_has_rich_title(&entry.activity_type) {
+        return discord_legacy_embed(delivery, render);
+    }
+    let localizer = OverlayLocalizer::new(locale);
+    let parsed = parse_location(&entry.content.location);
+
+    let mut title = localizer.discord_title(&entry.activity_type, &entry.actor_display_name);
+    if title.trim().is_empty() {
+        title = render.text.clone();
+    }
+
+    let mut description = String::new();
+    let is_invite = matches!(
+        entry.activity_type.as_str(),
+        "invite" | "requestInvite" | "inviteResponse" | "requestInviteResponse"
+    );
+    if is_invite {
+        let message = entry.content.detail.trim();
+        if !message.is_empty() && message != render.display_location.trim() {
+            description.push_str(&format!("\u{300c}{message}\u{300d}"));
+        }
+    }
+    if entry.activity_type == "GPS" {
+        let content = &entry.content;
+        let target = if !content.world_name.trim().is_empty() {
+            content.world_name.trim()
+        } else if !render.display_location.trim().is_empty() {
+            render.display_location.trim()
+        } else if !render.body.trim().is_empty() {
+            render.body.trim()
+        } else {
+            render.text.trim()
+        };
+        if !target.is_empty() {
+            description.push_str(&format!("\u{2192} {target}"));
+        }
+    } else if entry.activity_type == "Status" {
+        let status = localizer.status_text(&entry.content.status);
+        if !status.is_empty() {
+            description.push_str(&status);
+        }
+    } else if entry.activity_type == "AvatarChange" {
+        let avatar = entry.content.avatar_name.trim();
+        if !avatar.is_empty() {
+            description.push_str(avatar);
+        }
+    }
+
+    let author = build_discord_author(entry, render);
+
+    // footer is only for actual instances; non-world events (login etc.) get none
+    let mut footer = String::new();
+    if !parsed.instance_name.is_empty() {
+        footer.push_str(&format!("#{}", parsed.instance_name));
+        let access = localizer.access_label(&entry.content.location);
+        if !access.is_empty() {
+            footer.push_str(&format!(" - {access}"));
+        }
+        if let Some(flag) = region_flag_emoji(&parsed.region) {
+            footer.push_str(&format!(" {flag}"));
+        }
+    }
+
+    let thumbnail_url = if render.world_image_url.trim().is_empty() {
+        render.image_url.trim()
+    } else {
+        render.world_image_url.trim()
+    };
+    let thumbnail = if thumbnail_url.is_empty() {
+        json!({})
+    } else {
+        json!({ "url": thumbnail_url })
+    };
+
+    let mut embed = serde_json::Map::new();
+    embed.insert("title".into(), Value::String(title));
+    if !description.is_empty() {
+        embed.insert("description".into(), Value::String(description));
+    }
+    let url = launch_url(&parsed);
+    if !url.is_empty() {
+        embed.insert("url".into(), Value::String(url));
+    }
+    if !author.is_empty() {
+        embed.insert("author".into(), Value::Object(author));
+    }
+    if !footer.is_empty() {
+        embed.insert("footer".into(), json!({ "text": footer }));
+    }
+    embed.insert("timestamp".into(), Value::String(entry.created_at.clone()));
+    embed.insert("thumbnail".into(), thumbnail);
+
+    json!({
+        "content": null,
+        "embeds": [Value::Object(embed)],
+    })
+}
+
+fn launch_url(parsed: &ParsedLocation) -> String {
+    if parsed.world_id.is_empty() || parsed.instance_id.is_empty() {
+        return String::new();
+    }
+    let mut url = format!(
+        "{VRCHAT_SITE_ORIGIN}/home/launch?worldId={}&instanceId={}",
+        parsed.world_id, parsed.instance_id
+    );
+    if !parsed.short_name.is_empty() {
+        url.push_str("&shortName=");
+        url.push_str(&parsed.short_name);
+    }
+    url
+}
+
+fn build_discord_author(
+    entry: &vrcx_0_application::OverlayActivityEntry,
+    render: &RenderedNotification,
+) -> serde_json::Map<String, Value> {
+    let mut author = serde_json::Map::new();
+    if !entry.actor_display_name.trim().is_empty() {
+        author.insert(
+            "name".into(),
+            Value::String(entry.actor_display_name.clone()),
+        );
+    }
+    if !entry.actor_user_id.trim().is_empty() {
+        author.insert(
+            "url".into(),
+            Value::String(format!(
+                "{VRCHAT_SITE_ORIGIN}/home/user/{}",
+                entry.actor_user_id
+            )),
+        );
+    }
+    if !render.actor_image_url.trim().is_empty() {
+        author.insert(
+            "icon_url".into(),
+            Value::String(render.actor_image_url.clone()),
+        );
+    }
+    author
+}
+
+fn discord_legacy_embed(
+    delivery: &OverlayActivityDelivery,
+    render: &RenderedNotification,
+) -> Value {
+    let entry = &delivery.entry;
+    let description = if !render.body.trim().is_empty() {
+        String::new()
+    } else if !render.display_location.trim().is_empty() {
         format!("\u{2192} {}", render.display_location)
     } else if !entry.content.world_name.trim().is_empty() {
         format!("\u{2192} {}", entry.content.world_name)
-    } else if !render.body.trim().is_empty() {
-        render.body.clone()
     } else {
-        render.text.clone()
+        String::new()
     };
     let thumbnail = if render.image_url.trim().is_empty() {
         json!({})
     } else {
         json!({ "url": render.image_url })
     };
+    let author = build_discord_author(entry, render);
+    // the author header already shows the actor name, so prefer the body alone
+    // and fall back to the combined title+body text when there's no author/body
+    let title = if author.is_empty() || render.body.trim().is_empty() {
+        render.text.clone()
+    } else {
+        render.body.clone()
+    };
+    let mut embed = serde_json::Map::new();
+    if !author.is_empty() {
+        embed.insert("author".into(), Value::Object(author));
+    }
+    embed.insert("title".into(), Value::String(title));
+    if !description.is_empty() {
+        embed.insert("description".into(), Value::String(description));
+    }
+    embed.insert("thumbnail".into(), thumbnail);
+    embed.insert("timestamp".into(), Value::String(entry.created_at.clone()));
     json!({
         "content": null,
-        "embeds": [{
-            "title": &render.text,
-            "description": description,
-            "thumbnail": thumbnail,
-            "timestamp": &entry.created_at,
-        }]
+        "embeds": [embed],
     })
+}
+
+fn region_flag_emoji(region: &str) -> Option<&'static str> {
+    match region.trim().to_ascii_lowercase().as_str() {
+        "us" | "use" | "usw" => Some("\u{1F1FA}\u{1F1F8}"),
+        "eu" => Some("\u{1F1EA}\u{1F1FA}"),
+        "jp" => Some("\u{1F1EF}\u{1F1F5}"),
+        _ => None,
+    }
 }
 
 fn non_empty(value: &str) -> Option<&str> {
@@ -891,8 +1206,8 @@ mod tests {
     use crate::vr_overlay::OverlayLocale;
 
     use super::{
-        delivery_actor_image_user_id, overlay_notification_render, parse_webhook_fields,
-        render_delivery, webhook_payload, RenderedNotification,
+        avatar_name_from_file_name, delivery_actor_image_user_id, overlay_notification_render,
+        parse_webhook_fields, render_delivery, webhook_payload, RenderedNotification,
     };
 
     #[test]
@@ -902,6 +1217,7 @@ mod tests {
             &rendered(),
             "generic",
             &["location".into(), "locationId".into(), "localTime".into()],
+            OverlayLocale::En,
         );
 
         assert_eq!(
@@ -924,7 +1240,13 @@ mod tests {
     #[test]
     fn generic_webhook_fields_ignore_localized_names() {
         let fields = parse_webhook_fields(r#"["locationId","位置","タイトル"]"#);
-        let payload = webhook_payload(&delivery(), &rendered(), "generic", &fields);
+        let payload = webhook_payload(
+            &delivery(),
+            &rendered(),
+            "generic",
+            &fields,
+            OverlayLocale::En,
+        );
 
         assert_eq!(payload.as_object().unwrap().len(), 1);
         assert_eq!(
@@ -997,12 +1319,195 @@ mod tests {
         delivery.entry.content.display_location = "Group World groupPlus(Group Name)".into();
 
         let render = render_delivery(&delivery, OverlayLocale::ZhCn);
-        let payload = webhook_payload(&delivery, &render, "generic", &["location".into()]);
+        let payload = webhook_payload(
+            &delivery,
+            &render,
+            "generic",
+            &["location".into()],
+            OverlayLocale::En,
+        );
 
         assert_eq!(
             payload.get("location").and_then(|value| value.as_str()),
             Some("Group World 群组+(Group Name)")
         );
+    }
+
+    #[test]
+    fn discord_webhook_payload_builds_rich_invite_embed() {
+        let mut delivery = delivery();
+        delivery.entry.activity_type = "invite".into();
+        delivery.entry.actor_display_name = "Example".into();
+        delivery.entry.actor_user_id = "usr_abcdefg".into();
+        delivery.entry.created_at = "2026-06-29T08:11:00.000Z".into();
+        delivery.entry.content.location = "wrld_114514:810~private(usr_abcdefg)~region(jp)".into();
+        delivery.entry.content.world_id = "wrld_114514".into();
+        delivery.entry.content.world_name = "for Two".into();
+        delivery.entry.content.detail = "プラベいこ♡".into();
+        delivery.entry.content.image_url =
+            "https://api.vrchat.cloud/api/1/image/file_fallback/1/256".into();
+
+        let mut render = render_delivery(&delivery, OverlayLocale::En);
+        render.actor_image_url = "https://api.vrchat.cloud/api/1/image/file_icon/2/256".into();
+        render.world_image_url = "https://api.vrchat.cloud/api/1/file/file_world/8/file".into();
+
+        let payload = webhook_payload(&delivery, &render, "discord", &[], OverlayLocale::En);
+        let embed = &payload["embeds"][0];
+
+        assert_eq!(embed["title"].as_str(), Some("Example's invite"));
+        assert_eq!(embed["description"].as_str(), Some("「プラベいこ♡」"));
+        assert_eq!(
+            embed["url"].as_str(),
+            Some(
+                "https://vrchat.com/home/launch?worldId=wrld_114514&instanceId=810~private(usr_abcdefg)~region(jp)"
+            )
+        );
+        assert_eq!(embed["author"]["name"].as_str(), Some("Example"));
+        assert_eq!(
+            embed["author"]["url"].as_str(),
+            Some("https://vrchat.com/home/user/usr_abcdefg")
+        );
+        assert_eq!(
+            embed["author"]["icon_url"].as_str(),
+            Some("https://api.vrchat.cloud/api/1/image/file_icon/2/256")
+        );
+        assert_eq!(embed["footer"]["text"].as_str(), Some("#810 - Invite 🇯🇵"));
+        assert_eq!(
+            embed["timestamp"].as_str(),
+            Some("2026-06-29T08:11:00.000Z")
+        );
+        assert_eq!(
+            embed["thumbnail"]["url"].as_str(),
+            Some("https://api.vrchat.cloud/api/1/file/file_world/8/file")
+        );
+    }
+
+    #[test]
+    fn discord_webhook_payload_gps_uses_location_title_without_message() {
+        let mut delivery = delivery();
+        delivery.entry.activity_type = "GPS".into();
+        delivery.entry.actor_display_name = "Traveler".into();
+        delivery.entry.content.location =
+            "wrld_named:810~private(usr_x)~canRequestInvite~region(jp)".into();
+        delivery.entry.content.world_id = "wrld_named".into();
+        delivery.entry.content.world_name = "Named World".into();
+        delivery.entry.content.detail = "Named World invite+".into();
+
+        let render = render_delivery(&delivery, OverlayLocale::Ja);
+        let payload = webhook_payload(&delivery, &render, "discord", &[], OverlayLocale::Ja);
+        let embed = &payload["embeds"][0];
+
+        assert_eq!(embed["title"].as_str(), Some("Traveler が移動しました"));
+        assert_eq!(embed["description"].as_str(), Some("→ Named World"));
+        assert_eq!(
+            embed["footer"]["text"].as_str(),
+            Some("#810 - インバイト+ 🇯🇵")
+        );
+    }
+
+    #[test]
+    fn discord_webhook_payload_status_uses_status_title_and_target() {
+        let mut delivery = delivery();
+        delivery.entry.activity_type = "Status".into();
+        delivery.entry.actor_display_name = "Traveler".into();
+        delivery.entry.content.location = String::new();
+        delivery.entry.content.world_id = String::new();
+        delivery.entry.content.world_name = String::new();
+        delivery.entry.content.status = "join me".into();
+
+        let render = render_delivery(&delivery, OverlayLocale::Ja);
+        let payload = webhook_payload(&delivery, &render, "discord", &[], OverlayLocale::Ja);
+        let embed = &payload["embeds"][0];
+
+        assert_eq!(
+            embed["title"].as_str(),
+            Some("Traveler がステータスを変更しました")
+        );
+        assert_eq!(embed["description"].as_str(), Some("だれでもおいで"));
+        assert!(embed.get("footer").is_none());
+    }
+
+    #[test]
+    fn discord_webhook_payload_avatar_change_uses_rich_title_and_name() {
+        let mut delivery = delivery();
+        delivery.entry.activity_type = "AvatarChange".into();
+        delivery.entry.actor_display_name = "Traveler".into();
+        delivery.entry.content.location = String::new();
+        delivery.entry.content.world_id = String::new();
+        delivery.entry.content.world_name = String::new();
+        delivery.entry.content.avatar_name = "Maple".into();
+
+        let render = render_delivery(&delivery, OverlayLocale::Ja);
+        let payload = webhook_payload(&delivery, &render, "discord", &[], OverlayLocale::Ja);
+        let embed = &payload["embeds"][0];
+
+        assert_eq!(
+            embed["title"].as_str(),
+            Some("Traveler がアバターを変更しました")
+        );
+        assert_eq!(embed["description"].as_str(), Some("Maple"));
+        assert!(embed.get("footer").is_none());
+    }
+
+    #[test]
+    fn discord_webhook_payload_offline_uses_rich_title_without_world_name() {
+        let mut delivery = delivery();
+        delivery.entry.activity_type = "Offline".into();
+        delivery.entry.actor_display_name = "Traveler".into();
+        delivery.entry.content.location = String::new();
+        delivery.entry.content.world_id = String::new();
+        delivery.entry.content.world_name = String::new();
+
+        let render = render_delivery(&delivery, OverlayLocale::Ja);
+        let payload = webhook_payload(&delivery, &render, "discord", &[], OverlayLocale::Ja);
+        let embed = &payload["embeds"][0];
+
+        assert_eq!(embed["author"]["name"].as_str(), Some("Traveler"));
+        assert_eq!(
+            embed["title"].as_str(),
+            Some("Traveler がログアウトしました")
+        );
+        assert!(embed.get("description").is_none());
+        assert!(embed.get("footer").is_none());
+    }
+
+    #[test]
+    fn discord_webhook_payload_online_uses_rich_title() {
+        let mut delivery = delivery();
+        delivery.entry.activity_type = "Online".into();
+        delivery.entry.actor_display_name = "Traveler".into();
+        delivery.entry.content.location = String::new();
+        delivery.entry.content.world_id = String::new();
+        delivery.entry.content.world_name = String::new();
+
+        let render = render_delivery(&delivery, OverlayLocale::Ja);
+        let payload = webhook_payload(&delivery, &render, "discord", &[], OverlayLocale::Ja);
+        let embed = &payload["embeds"][0];
+
+        assert_eq!(embed["author"]["name"].as_str(), Some("Traveler"));
+        assert_eq!(embed["title"].as_str(), Some("Traveler がログインしました"));
+        assert!(embed.get("footer").is_none());
+    }
+
+    #[test]
+    fn discord_webhook_payload_falls_back_to_legacy_for_unsupported_type() {
+        let mut delivery = delivery();
+        delivery.entry.activity_type = "Bio".into();
+        delivery.entry.actor_display_name = "Traveler".into();
+
+        let render = render_delivery(&delivery, OverlayLocale::Ja);
+        let payload = webhook_payload(&delivery, &render, "discord", &[], OverlayLocale::Ja);
+        let embed = &payload["embeds"][0];
+
+        assert_eq!(embed["author"]["name"].as_str(), Some("Traveler"));
+        assert!(embed.get("footer").is_none());
+    }
+
+    #[test]
+    fn avatar_name_from_file_name_extracts_name() {
+        let raw = "Avatar - Name - Image - 2022․3․22f1_1_standalonewindows_Release";
+        assert_eq!(avatar_name_from_file_name(raw).as_deref(), Some("Name"));
+        assert_eq!(avatar_name_from_file_name("just a name"), None);
     }
 
     fn rendered() -> RenderedNotification {
@@ -1012,6 +1517,8 @@ mod tests {
             text: "Traveler joined Named World".into(),
             display_location: "Named World public".into(),
             image_url: String::new(),
+            actor_image_url: String::new(),
+            world_image_url: String::new(),
         }
     }
 

--- a/crates/runtime-host/src/vr_overlay/localization.rs
+++ b/crates/runtime-host/src/vr_overlay/localization.rs
@@ -193,11 +193,28 @@ impl OverlayLocalizer {
     }
 }
 
-pub(crate) fn discord_has_rich_title(activity_type: &str) -> bool {
-    discord_title_key(activity_type).is_some()
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DiscordEmbedKind {
+    Invite,
+    Gps,
+    Status,
+    AvatarChange,
+    Other,
 }
 
-fn discord_title_key(activity_type: &str) -> Option<&'static str> {
+pub(crate) fn discord_embed_kind(activity_type: &str) -> DiscordEmbedKind {
+    match activity_type {
+        "invite" | "requestInvite" | "inviteResponse" | "requestInviteResponse" => {
+            DiscordEmbedKind::Invite
+        }
+        "GPS" => DiscordEmbedKind::Gps,
+        "Status" => DiscordEmbedKind::Status,
+        "AvatarChange" => DiscordEmbedKind::AvatarChange,
+        _ => DiscordEmbedKind::Other,
+    }
+}
+
+pub(crate) fn discord_title_key(activity_type: &str) -> Option<&'static str> {
     match activity_type {
         "invite" => Some("overlay.discord.title.invite"),
         "requestInvite" => Some("overlay.discord.title.request_invite"),

--- a/crates/runtime-host/src/vr_overlay/localization.rs
+++ b/crates/runtime-host/src/vr_overlay/localization.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, sync::OnceLock};
 
-use serde_json::Value;
+use serde_json::{json, Value};
 use vrcx_0_application::OverlayActivityText;
 use vrcx_0_core::location::{
     format_display_location_with_labels, parse_location, DisplayLocationLabels,
@@ -121,6 +121,48 @@ impl OverlayLocalizer {
         self.label("overlay.generic_instance_location", "an instance")
     }
 
+    pub(crate) fn discord_title(&self, activity_type: &str, name: &str) -> String {
+        let name = name.trim();
+        let Some(key) = discord_title_key(activity_type) else {
+            return name.to_string();
+        };
+        let template = catalog().text(self.locale.as_str(), key, "{name}");
+        collapse_whitespace(&interpolate(&template, &json!({ "name": name })))
+    }
+
+    pub(crate) fn status_text(&self, status: &str) -> String {
+        let status = status.trim();
+        if status.is_empty() {
+            return String::new();
+        }
+        match status_label_key(status) {
+            Some(key) => self.label(key, status),
+            None => status.to_string(),
+        }
+    }
+
+    pub(crate) fn access_label(&self, location: &str) -> String {
+        let parsed = parse_location(location);
+        match parsed.access_type_name.as_str() {
+            "" => String::new(),
+            "public" => self.label("overlay.access.public", "Public"),
+            "invite" => self.label("overlay.access.invite", "Invite"),
+            "invite+" => self.label("overlay.access.invite_plus", "Invite+"),
+            "friends" => self.label("overlay.access.friends", "Friends"),
+            "friends+" => self.label("overlay.access.friends_plus", "Friends+"),
+            "group" => self.label("overlay.access.group", "Group"),
+            "groupPublic" => {
+                let group = self.label("overlay.access.group", "Group");
+                self.group_access_label(&group, "overlay.access.group_public", "groupPublic")
+            }
+            "groupPlus" => {
+                let group = self.label("overlay.access.group", "Group");
+                self.group_access_label(&group, "overlay.access.group_plus", "groupPlus")
+            }
+            other => other.to_string(),
+        }
+    }
+
     fn group_access_label(&self, group: &str, key: &str, fallback: &str) -> String {
         let label = self.label(key, fallback);
         if label.starts_with(group) {
@@ -148,6 +190,25 @@ impl OverlayLocalizer {
         let mut localized = object.clone();
         localized.insert("status".to_string(), Value::String(label));
         Cow::Owned(Value::Object(localized))
+    }
+}
+
+pub(crate) fn discord_has_rich_title(activity_type: &str) -> bool {
+    discord_title_key(activity_type).is_some()
+}
+
+fn discord_title_key(activity_type: &str) -> Option<&'static str> {
+    match activity_type {
+        "invite" => Some("overlay.discord.title.invite"),
+        "requestInvite" => Some("overlay.discord.title.request_invite"),
+        "inviteResponse" => Some("overlay.discord.title.invite_response"),
+        "requestInviteResponse" => Some("overlay.discord.title.request_invite_response"),
+        "GPS" => Some("overlay.discord.title.gps"),
+        "Status" => Some("overlay.discord.title.status"),
+        "AvatarChange" => Some("overlay.discord.title.avatar_change"),
+        "Online" => Some("overlay.discord.title.online"),
+        "Offline" => Some("overlay.discord.title.offline"),
+        _ => None,
     }
 }
 

--- a/crates/runtime-host/src/vr_overlay/localization/overlay_notifications.json
+++ b/crates/runtime-host/src/vr_overlay/localization/overlay_notifications.json
@@ -50,7 +50,16 @@
             "overlay.status.active": "Online",
             "overlay.status.join_me": "Join Me",
             "overlay.status.ask_me": "Ask Me",
-            "overlay.status.busy": "Do Not Disturb"
+            "overlay.status.busy": "Do Not Disturb",
+            "overlay.discord.title.invite": "{name}'s invite",
+            "overlay.discord.title.request_invite": "{name}'s invite request",
+            "overlay.discord.title.invite_response": "{name}'s invite response",
+            "overlay.discord.title.request_invite_response": "{name}'s invite request response",
+            "overlay.discord.title.gps": "{name}'s location",
+            "overlay.discord.title.status": "{name} changed status",
+            "overlay.discord.title.avatar_change": "{name} changed avatar",
+            "overlay.discord.title.online": "{name} logged in",
+            "overlay.discord.title.offline": "{name} logged out"
         },
         "zh-CN": {
             "notifications.has_joined": "加入了房间",
@@ -100,7 +109,16 @@
             "overlay.status.active": "在线",
             "overlay.status.join_me": "欢迎加入",
             "overlay.status.ask_me": "忙碌",
-            "overlay.status.busy": "请勿打扰"
+            "overlay.status.busy": "请勿打扰",
+            "overlay.discord.title.invite": "{name} 的邀请",
+            "overlay.discord.title.request_invite": "{name} 的邀请请求",
+            "overlay.discord.title.invite_response": "{name} 的邀请回应",
+            "overlay.discord.title.request_invite_response": "{name} 的邀请请求回应",
+            "overlay.discord.title.gps": "{name} 的当前位置",
+            "overlay.discord.title.status": "{name} 更改了状态",
+            "overlay.discord.title.avatar_change": "{name} 更改了模型",
+            "overlay.discord.title.online": "{name} 已登录",
+            "overlay.discord.title.offline": "{name} 已登出"
         },
         "zh-TW": {
             "notifications.has_joined": "已加入",
@@ -150,7 +168,16 @@
             "overlay.status.active": "上線",
             "overlay.status.join_me": "加入我",
             "overlay.status.ask_me": "詢問我",
-            "overlay.status.busy": "請勿打擾"
+            "overlay.status.busy": "請勿打擾",
+            "overlay.discord.title.invite": "{name} 的邀請",
+            "overlay.discord.title.request_invite": "{name} 的邀請請求",
+            "overlay.discord.title.invite_response": "{name} 的邀請回應",
+            "overlay.discord.title.request_invite_response": "{name} 的邀請請求回應",
+            "overlay.discord.title.gps": "{name} 的目前位置",
+            "overlay.discord.title.status": "{name} 變更了狀態",
+            "overlay.discord.title.avatar_change": "{name} 變更了角色",
+            "overlay.discord.title.online": "{name} 已登入",
+            "overlay.discord.title.offline": "{name} 已登出"
         },
         "ja": {
             "notifications.has_joined": "が参加しました",
@@ -200,7 +227,16 @@
             "overlay.status.active": "オンライン",
             "overlay.status.join_me": "だれでもおいで",
             "overlay.status.ask_me": "きいてみてね",
-            "overlay.status.busy": "取り込み中"
+            "overlay.status.busy": "取り込み中",
+            "overlay.discord.title.invite": "{name} からの招待",
+            "overlay.discord.title.request_invite": "{name} からの招待リクエスト",
+            "overlay.discord.title.invite_response": "{name} からの招待への返信",
+            "overlay.discord.title.request_invite_response": "{name} からの招待リクエストへの返信",
+            "overlay.discord.title.gps": "{name} が移動しました",
+            "overlay.discord.title.status": "{name} がステータスを変更しました",
+            "overlay.discord.title.avatar_change": "{name} がアバターを変更しました",
+            "overlay.discord.title.online": "{name} がログインしました",
+            "overlay.discord.title.offline": "{name} がログアウトしました"
         },
         "ko": {
             "notifications.has_joined": "가입했습니다",
@@ -250,7 +286,16 @@
             "overlay.status.active": "온라인",
             "overlay.status.join_me": "조인 가능",
             "overlay.status.ask_me": "조인 문의",
-            "overlay.status.busy": "방해 금지"
+            "overlay.status.busy": "방해 금지",
+            "overlay.discord.title.invite": "{name}님의 초대",
+            "overlay.discord.title.request_invite": "{name}님의 초대 요청",
+            "overlay.discord.title.invite_response": "{name}님의 초대 응답",
+            "overlay.discord.title.request_invite_response": "{name}님의 초대 요청 응답",
+            "overlay.discord.title.gps": "{name}님의 현재 위치",
+            "overlay.discord.title.status": "{name}님이 상태를 변경했습니다",
+            "overlay.discord.title.avatar_change": "{name}님이 아바타를 변경했습니다",
+            "overlay.discord.title.online": "{name}님이 로그인했습니다",
+            "overlay.discord.title.offline": "{name}님이 로그아웃했습니다"
         }
     }
 }

--- a/crates/runtime-host/src/vr_overlay/mod.rs
+++ b/crates/runtime-host/src/vr_overlay/mod.rs
@@ -2,7 +2,7 @@ mod eligibility;
 mod localization;
 mod manager;
 
-pub(crate) use localization::{OverlayLocale, OverlayLocalizer};
+pub(crate) use localization::{discord_has_rich_title, OverlayLocale, OverlayLocalizer};
 mod preview_bridge;
 mod runtime;
 mod service;

--- a/crates/runtime-host/src/vr_overlay/mod.rs
+++ b/crates/runtime-host/src/vr_overlay/mod.rs
@@ -2,7 +2,9 @@ mod eligibility;
 mod localization;
 mod manager;
 
-pub(crate) use localization::{discord_has_rich_title, OverlayLocale, OverlayLocalizer};
+pub(crate) use localization::{
+    discord_embed_kind, discord_title_key, DiscordEmbedKind, OverlayLocale, OverlayLocalizer,
+};
 mod preview_bridge;
 mod runtime;
 mod service;

--- a/scripts/generate-native-locales.mjs
+++ b/scripts/generate-native-locales.mjs
@@ -110,7 +110,31 @@ const overlayPathKeys = [
     ['overlay.status.active', ['dialog', 'user', 'status', 'online']],
     ['overlay.status.join_me', ['dialog', 'user', 'status', 'join_me']],
     ['overlay.status.ask_me', ['dialog', 'user', 'status', 'ask_me']],
-    ['overlay.status.busy', ['dialog', 'user', 'status', 'busy']]
+    ['overlay.status.busy', ['dialog', 'user', 'status', 'busy']],
+    ['overlay.discord.title.invite', ['overlay', 'discord', 'title', 'invite']],
+    [
+        'overlay.discord.title.request_invite',
+        ['overlay', 'discord', 'title', 'request_invite']
+    ],
+    [
+        'overlay.discord.title.invite_response',
+        ['overlay', 'discord', 'title', 'invite_response']
+    ],
+    [
+        'overlay.discord.title.request_invite_response',
+        ['overlay', 'discord', 'title', 'request_invite_response']
+    ],
+    ['overlay.discord.title.gps', ['overlay', 'discord', 'title', 'gps']],
+    ['overlay.discord.title.status', ['overlay', 'discord', 'title', 'status']],
+    [
+        'overlay.discord.title.avatar_change',
+        ['overlay', 'discord', 'title', 'avatar_change']
+    ],
+    ['overlay.discord.title.online', ['overlay', 'discord', 'title', 'online']],
+    [
+        'overlay.discord.title.offline',
+        ['overlay', 'discord', 'title', 'offline']
+    ]
 ];
 const shellPathKeys = pathKeysFromDottedKeys([
     'nativeShell.tray.open',

--- a/src-tauri/src/bootstrap.rs
+++ b/src-tauri/src/bootstrap.rs
@@ -1149,7 +1149,7 @@ mod tests {
         );
         assert_eq!(
             auth_failure_notification_labels_for_language("zh-TW").title,
-            "VRChat 登入已失效"
+            "VRChat 登入已過期"
         );
         assert_eq!(
             auth_failure_notification_labels_for_language("ja").title,

--- a/src-tauri/src/localization/shell_locale.rs
+++ b/src-tauri/src/localization/shell_locale.rs
@@ -211,11 +211,11 @@ mod tests {
     fn routes_chinese_script_and_region_variants() {
         assert_eq!(
             auth_failure_notification_labels_for_language("zh-Hant").title,
-            "VRChat 登入已失效"
+            "VRChat 登入已過期"
         );
         assert_eq!(
             auth_failure_notification_labels_for_language("zh_HK").title,
-            "VRChat 登入已失效"
+            "VRChat 登入已過期"
         );
         assert_eq!(
             auth_failure_notification_labels_for_language("zh-Hans").title,

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -130,7 +130,20 @@
             "players": "{count} players",
             "instance_duration": "Instance {duration}"
         },
-        "generic_instance_location": "an instance"
+        "generic_instance_location": "an instance",
+        "discord": {
+            "title": {
+                "invite": "{name}'s invite",
+                "request_invite": "{name}'s invite request",
+                "invite_response": "{name}'s invite response",
+                "request_invite_response": "{name}'s invite request response",
+                "gps": "{name}'s location",
+                "status": "{name} changed status",
+                "avatar_change": "{name} changed avatar",
+                "online": "{name} logged in",
+                "offline": "{name} logged out"
+            }
+        }
     },
     "nativeShell": {
         "tray": {

--- a/src/localization/ja.json
+++ b/src/localization/ja.json
@@ -130,7 +130,20 @@
             "players": "{count}人",
             "instance_duration": "滞在 {duration}"
         },
-        "generic_instance_location": "インスタンス"
+        "generic_instance_location": "インスタンス",
+        "discord": {
+            "title": {
+                "invite": "{name} からの招待",
+                "request_invite": "{name} からの招待リクエスト",
+                "invite_response": "{name} からの招待への返信",
+                "request_invite_response": "{name} からの招待リクエストへの返信",
+                "gps": "{name} が移動しました",
+                "status": "{name} がステータスを変更しました",
+                "avatar_change": "{name} がアバターを変更しました",
+                "online": "{name} がログインしました",
+                "offline": "{name} がログアウトしました"
+            }
+        }
     },
     "nativeShell": {
         "tray": {

--- a/src/localization/ko.json
+++ b/src/localization/ko.json
@@ -130,7 +130,20 @@
             "players": "{count}명",
             "instance_duration": "체류 {duration}"
         },
-        "generic_instance_location": "인스턴스"
+        "generic_instance_location": "인스턴스",
+        "discord": {
+            "title": {
+                "invite": "{name}님의 초대",
+                "request_invite": "{name}님의 초대 요청",
+                "invite_response": "{name}님의 초대 응답",
+                "request_invite_response": "{name}님의 초대 요청 응답",
+                "gps": "{name}님의 현재 위치",
+                "status": "{name}님이 상태를 변경했습니다",
+                "avatar_change": "{name}님이 아바타를 변경했습니다",
+                "online": "{name}님이 로그인했습니다",
+                "offline": "{name}님이 로그아웃했습니다"
+            }
+        }
     },
     "nativeShell": {
         "tray": {

--- a/src/localization/zh-CN.json
+++ b/src/localization/zh-CN.json
@@ -130,7 +130,20 @@
             "players": "{count} 名玩家",
             "instance_duration": "停留 {duration}"
         },
-        "generic_instance_location": "某个房间"
+        "generic_instance_location": "某个房间",
+        "discord": {
+            "title": {
+                "invite": "{name} 的邀请",
+                "request_invite": "{name} 的邀请请求",
+                "invite_response": "{name} 的邀请回应",
+                "request_invite_response": "{name} 的邀请请求回应",
+                "gps": "{name} 的当前位置",
+                "status": "{name} 更改了状态",
+                "avatar_change": "{name} 更改了模型",
+                "online": "{name} 已登录",
+                "offline": "{name} 已登出"
+            }
+        }
     },
     "nativeShell": {
         "tray": {

--- a/src/localization/zh-TW.json
+++ b/src/localization/zh-TW.json
@@ -130,7 +130,20 @@
             "players": "{count} 位玩家",
             "instance_duration": "停留 {duration}"
         },
-        "generic_instance_location": "一個房間"
+        "generic_instance_location": "一個房間",
+        "discord": {
+            "title": {
+                "invite": "{name} 的邀請",
+                "request_invite": "{name} 的邀請請求",
+                "invite_response": "{name} 的邀請回應",
+                "request_invite_response": "{name} 的邀請請求回應",
+                "gps": "{name} 的目前位置",
+                "status": "{name} 變更了狀態",
+                "avatar_change": "{name} 變更了角色",
+                "online": "{name} 已登入",
+                "offline": "{name} 已登出"
+            }
+        }
     },
     "nativeShell": {
         "tray": {


### PR DESCRIPTION
# Description
This PR enriches the Discord webhook embeds with author headers, localized rich titles, instance/region footers, world thumbnails, and "Launch" links to worlds and users.

Screenshots:
<img width="364" height="262" alt="image" src="https://github.com/user-attachments/assets/74acd478-2ebd-4f8a-9dd2-64cd5d385611" />

# Main Files Changed
## crates/runtime-host/src/notification/dispatcher.rs
### Added functions
- build_discord_author(entry, render) -> Map
  Builds the embed author header (name, URL, icon).
- discord_legacy_embed(delivery, render) -> Value
  Builds a legacy title/description embed; also renders the author header.
  Used as a fallback for activity types that don't have a rich Discord title.
- (async) resolve_delivery_avatar_name(web, db, endpoint, delivery)
  A function to retrieve the avatar name by calling the VRChat File API using the image fileId.
  A similar function already exists on the frontend, but as it was not yet available on the Rust side, I have added it as a new function.
- avatar_name_from_file_name(file_name) -> Option<String>
  A function to extract the avatar name from the file name (used by resolve_delivery_avatar_name).

- (test) discord_webhook_payload_gps_uses_location_title_without_message()
- (test) discord_webhook_payload_status_uses_status_title_and_target()
- (test) discord_webhook_payload_avatar_change_uses_rich_title_and_name()
- (test) discord_webhook_payload_offline_uses_rich_title_without_world_name()
- (test) discord_webhook_payload_online_uses_rich_title()
- (test) discord_webhook_payload_falls_back_to_legacy_for_unsupported_type()
- (test) avatar_name_from_file_name_extracts_name()

### Modified functions
- emit_overlay_activity_delivery(&self, delivery)
  Calls resolve_delivery_avatar_name only for Discord Webhooks.
- discord_webhook_payload(delivery, render, locale)
  Mostly rewritten.
  First determines if discord_has_rich_title is true; if false, it falls back to discord_legacy_embed.

## crates/runtime-host/src/vr_overlay/localization.rs
### Added functions
- discord_has_rich_title(activity_type) -> bool
  Determines if a Discord Webhook-specific title exists (used for fallback branching).
- status_text(&self, status) -> String
  Localizes status change text.
- access_label(&self, location) -> String
  Localizes instance types (e.g., Invite+).
- discord_title_key(activity_type) -> Option<&'static str>

- (test) discord_webhook_payload_builds_rich_invite_embed()

## Localization
- src/localization/*.json
  Added overlay.discord.title.* / event.* (and generic_instance_location) for five languages.
  (overlay.access.* is reused from existing keys.)
- scripts/generate-native-locales.mjs
  Added the overlay.discord.* keys to the export list so they get bundled for the native runtime.
- crates/runtime-host/src/vr_overlay/localization/overlay_notifications.json
  Regenerated bundle that the native runtime actually reads (output of the script above).

## Test fix
- src-tauri/src/bootstrap.rs / src-tauri/src/localization/shell_locale.rs
  The hardcoded zh-Hant auth-failure title ("VRChat 登入已失效") didn't match the source
  string in zh-TW.json ("VRChat 登入已過期"), which made the localization consistency test
  (routes_chinese_script_and_region_variants) fail. Aligned the Rust strings to the json.

# Details
Note: I'm still learning Rust and used an LLM to help with structure and non-Japanese translations, so feedback on idioms or wording is very welcome.

The reason I added new localization strings for invites, etc., under overlay.discord.* is that existing localization strings (like notifications.invite) combine world names and other info into a single line, which I determined would be redundant for this Discord Embed.
Also, existing strings like notifications.has_joined start with "has" (in Japanese, they start with "が~"), which felt unnatural for this context.
This is the same for existing XSOverlay/WayVR notifications and desktop notifications. I considered fixing them, but I felt it was outside the scope of this PR, so I added new strings instead.

Closes #235