### PR TITLE
Add CLA signatures

### DIFF
--- a/signatures/version1/cla.json
+++ b/signatures/version1/cla.json
@@ -1,76 +1,100 @@
 {
-  "signedContributors": [
-    {
-      "name": "Dreaminko",
-      "id": 62631990,
-      "comment_id": 4855124150,
-      "created_at": "2026-07-01T12:57:54Z",
-      "repoId": 1201710991,
-      "pullRequestNo": 252
-    },
-    {
-      "name": "aeongdesu",
-      "id": 50764666,
-      "comment_id": 4855440222,
-      "created_at": "2026-07-01T13:28:17Z",
-      "repoId": 1201710991,
-      "pullRequestNo": 253
-    },
-    {
-      "name": "MungbeanOuO",
-      "id": 42833513,
-      "comment_id": 4855459151,
-      "created_at": "2026-07-01T13:30:29Z",
-      "repoId": 1201710991,
-      "pullRequestNo": 253
-    },
-    {
-      "name": "neco222",
-      "id": 107422195,
-      "comment_id": 4855497235,
-      "created_at": "2026-07-01T13:34:51Z",
-      "repoId": 1201710991,
-      "pullRequestNo": 253
-    },
-    {
-      "name": "xuan25",
-      "id": 29728710,
-      "comment_id": 4855583690,
-      "created_at": "2026-07-01T13:41:57Z",
-      "repoId": 1201710991,
-      "pullRequestNo": 253
-    },
-    {
-      "name": "CyanChanges",
-      "id": 68551684,
-      "comment_id": 4855697005,
-      "created_at": "2026-07-01T13:49:57Z",
-      "repoId": 1201710991,
-      "pullRequestNo": 253
-    },
-    {
-      "name": "flower-elf",
-      "id": 47104993,
-      "comment_id": 4855854634,
-      "created_at": "2026-07-01T14:00:15Z",
-      "repoId": 1201710991,
-      "pullRequestNo": 253
-    },
-    {
-      "name": "Null-K",
-      "id": 42692963,
-      "comment_id": 4856028510,
-      "created_at": "2026-07-01T14:12:32Z",
-      "repoId": 1201710991,
-      "pullRequestNo": 253
-    },
-    {
-      "name": "asdy31415",
-      "id": 107017897,
-      "comment_id": 4864937609,
-      "created_at": "2026-07-02T10:56:21Z",
-      "repoId": 1201710991,
-      "pullRequestNo": 256
-    }
-  ]
+    "signedContributors": [
+        {
+            "name": "Dreaminko",
+            "id": 62631990,
+            "comment_id": 4855324826,
+            "created_at": "2026-07-01T13:15:41Z",
+            "repoId": 1201710991,
+            "pullRequestNo": 253
+        },
+        {
+            "name": "aeongdesu",
+            "id": 50764666,
+            "comment_id": 4855440222,
+            "created_at": "2026-07-01T13:28:17Z",
+            "repoId": 1201710991,
+            "pullRequestNo": 253
+        },
+        {
+            "name": "MungbeanOuO",
+            "id": 42833513,
+            "comment_id": 4855459151,
+            "created_at": "2026-07-01T13:30:29Z",
+            "repoId": 1201710991,
+            "pullRequestNo": 253
+        },
+        {
+            "name": "neco222",
+            "id": 107422195,
+            "comment_id": 4855497235,
+            "created_at": "2026-07-01T13:34:51Z",
+            "repoId": 1201710991,
+            "pullRequestNo": 253
+        },
+        {
+            "name": "xuan25",
+            "id": 29728710,
+            "comment_id": 4855583690,
+            "created_at": "2026-07-01T13:41:57Z",
+            "repoId": 1201710991,
+            "pullRequestNo": 253
+        },
+        {
+            "name": "CyanChanges",
+            "id": 68551684,
+            "comment_id": 4855697005,
+            "created_at": "2026-07-01T13:49:57Z",
+            "repoId": 1201710991,
+            "pullRequestNo": 253
+        },
+        {
+            "name": "flower-elf",
+            "id": 47104993,
+            "comment_id": 4855854634,
+            "created_at": "2026-07-01T14:00:15Z",
+            "repoId": 1201710991,
+            "pullRequestNo": 253
+        },
+        {
+            "name": "Null-K",
+            "id": 42692963,
+            "comment_id": 4856028510,
+            "created_at": "2026-07-01T14:12:32Z",
+            "repoId": 1201710991,
+            "pullRequestNo": 253
+        },
+        {
+            "name": "poyotanp",
+            "id": 175612994,
+            "comment_id": 4856696762,
+            "created_at": "2026-07-01T15:05:16Z",
+            "repoId": 1201710991,
+            "pullRequestNo": 253
+        },
+        {
+            "name": "artifishvr",
+            "id": 59352535,
+            "comment_id": 4860224094,
+            "created_at": "2026-07-01T21:34:57Z",
+            "repoId": 1201710991,
+            "pullRequestNo": 253
+        },
+        {
+            "name": "blufish1234",
+            "id": 97332474,
+            "comment_id": 4864992456,
+            "created_at": "2026-07-02T11:03:25Z",
+            "repoId": 1201710991,
+            "pullRequestNo": 253
+        },
+        {
+            "name": "asdy31415",
+            "id": 107017897,
+            "comment_id": 4864937609,
+            "created_at": "2026-07-02T10:56:21Z",
+            "repoId": 1201710991,
+            "pullRequestNo": 256
+        }
+    ]
 }


### PR DESCRIPTION
This pull request updates the contributor license agreement (CLA) records in `signatures/version1/cla.json` for pull request number 253. The main changes are updating an existing signature and adding new contributor signatures.

Updates to existing signatures:

* Updated the signature details for user `Dreaminko` to reflect a new `comment_id`, `created_at` timestamp, and associated pull request number (now 253 instead of 252).

New contributor signatures:

* Added new CLA signature entries for users `poyotanp`, `artifishvr`, and `blufish1234`, each with their respective IDs, comment IDs, timestamps, and association to pull request 253.