### PR TITLE
fix(ui): preserve newlines in field descriptions

### DIFF
--- a/src/ui/shadcn/field.tsx
+++ b/src/ui/shadcn/field.tsx
@@ -131,7 +131,7 @@ function FieldDescription({ className, ...props }: React.ComponentProps<'p'>) {
         <p
             data-slot="field-description"
             className={cn(
-                'text-muted-foreground text-left text-sm leading-normal font-normal group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5',
+                'text-muted-foreground text-left text-sm leading-normal font-normal whitespace-pre-line group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5',
                 'last:mt-0 nth-last-2:-mt-1',
                 '[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4',
                 className


### PR DESCRIPTION
- Keeps normal whitespace collapsing behavior by using `whitespace-pre-line`.