### PR TITLE
Changed gallery translation

### DIFF
--- a/src/localization/ja.json
+++ b/src/localization/ja.json
@@ -1345,7 +1345,7 @@
                 "header": "メディア",
                 "screenshot": "スクリーンショット",
                 "screenshot_description": "スクリーンショットを表示・管理",
-                "gallery": "インベントリの管理",
+                "gallery": "ギャラリー",
                 "gallery_description": "ギャラリーや絵文字、プリント、アイテムなどを管理",
                 "inventory": "インベントリ",
                 "inventory_description": "Emoji、ステッカー、アイテム、装飾を管理"


### PR DESCRIPTION
According to the [glossary](https://github.com/Map1en/VRCX-0/blob/master/src/localization/GLOSSARY.md), "gallery" should be translated as "ギャラリー". However, the existing translation was using "インベントリの管理" (inventory management), which does not match the glossary and does not reflect the actual meaning of "gallery".