### PR TITLE
feat: use standard image for standard density instead of shrinked

### DIFF
--- a/src/features/favorites/components/FavoriteCard.tsx
+++ b/src/features/favorites/components/FavoriteCard.tsx
@@ -480,10 +480,10 @@ const FavoriteCard = memo(function FavoriteCard({
                         aspectRatio: String(densityConfig.imageAspectRatio)
                     }}
                 >
-                    {(item.imageUrl || item.imageUrl) && !item.isUnavailable ? (
+                    {item.imageUrl && !item.isUnavailable ? (
                         <img
                             src={
-                                densityConfig.value == 'compact'
+                                densityConfig.value === 'compact'
                                     ? item.imageSmallUrl || item.imageUrl
                                     : item.imageUrl
                             }

--- a/src/features/favorites/components/FavoriteCard.tsx
+++ b/src/features/favorites/components/FavoriteCard.tsx
@@ -58,6 +58,7 @@ type FavoriteCardItem = {
     title?: string;
     subtitle?: string;
     imageUrl?: string;
+    imageSmallUrl?: string;
     seedData?: FavoriteCardSeedData | null;
     groupLabel?: string;
     isPrivate?: boolean;
@@ -479,9 +480,13 @@ const FavoriteCard = memo(function FavoriteCard({
                         aspectRatio: String(densityConfig.imageAspectRatio)
                     }}
                 >
-                    {item.imageUrl && !item.isUnavailable ? (
+                    {(item.imageUrl || item.imageUrl) && !item.isUnavailable ? (
                         <img
-                            src={item.imageUrl}
+                            src={
+                                densityConfig.value == 'compact'
+                                    ? item.imageSmallUrl || item.imageUrl
+                                    : item.imageUrl
+                            }
                             alt={item.title}
                             loading="lazy"
                             className="size-full object-cover"
@@ -590,9 +595,9 @@ const FavoriteCard = memo(function FavoriteCard({
                         isFriendCard && 'bg-muted rounded-full border'
                     )}
                 >
-                    {item.imageUrl ? (
+                    {item.imageSmallUrl || item.imageUrl ? (
                         <img
-                            src={item.imageUrl}
+                            src={item.imageSmallUrl || item.imageUrl}
                             alt={item.title}
                             loading="lazy"
                             className="size-full object-cover"

--- a/src/features/favorites/favoritesItems.ts
+++ b/src/features/favorites/favoritesItems.ts
@@ -46,9 +46,16 @@ export function sortFavoriteItems(items: any, sortValue: any) {
     });
 }
 
-export function shrinkFavoriteImage(url: any) {
+export function resolveFavoriteImage(url: unknown) {
+    return typeof url === 'string' ? convertFileUrlToImageUrl(url, 256) : '';
+}
+
+export function shrinkFavoriteImage(url: unknown) {
+    if (typeof url !== 'string') {
+        return '';
+    }
     const normalized = convertFileUrlToImageUrl(url, 128);
-    if (typeof normalized !== 'string' || !normalized) {
+    if (!normalized) {
         return '';
     }
     return normalized.includes('/256')

--- a/src/features/favorites/favoritesPageData.test.ts
+++ b/src/features/favorites/favoritesPageData.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildFavoriteRemoteItemsByGroup } from './favoritesPageData';
+import {
+    buildFavoriteAvatarHistoryItems,
+    buildFavoriteLocalItemsByGroup,
+    buildFavoriteRemoteItemsByGroup
+} from './favoritesPageData';
 
 function buildWorldItems({
     cachedWorldDetail,
@@ -484,6 +488,77 @@ describe('favorites page data helpers', () => {
                 }),
                 isPrivate: false,
                 isUnavailable: false
+            })
+        ]);
+    });
+
+    it('keeps full and compact image urls separate for remote world cards', () => {
+        const items = buildWorldItems({
+            remoteWorldDetail: {
+                name: 'Image World',
+                thumbnailImageUrl: 'https://example.test/thumb/256',
+                imageUrl: 'https://example.test/full/256'
+            }
+        });
+
+        expect(items).toEqual([
+            expect.objectContaining({
+                imageUrl: 'https://example.test/full/256',
+                imageSmallUrl: 'https://example.test/thumb/128'
+            })
+        ]);
+    });
+
+    it('keeps full and compact image urls separate for local world cards', () => {
+        const items = buildFavoriteLocalItemsByGroup({
+            kind: 'world',
+            localGroups: [
+                {
+                    key: 'Worlds',
+                    label: 'Worlds'
+                }
+            ],
+            localWorldFavorites: {
+                Worlds: ['wrld_local']
+            },
+            localWorldDetailsById: {
+                wrld_local: {
+                    id: 'wrld_local',
+                    name: 'Local World',
+                    thumbnailImageUrl: 'https://example.test/local-thumb/256',
+                    imageUrl: 'https://example.test/local-full/256'
+                }
+            },
+            sortValue: 'date',
+            t: (key: string) => key
+        })['Worlds'];
+
+        expect(items).toEqual([
+            expect.objectContaining({
+                imageUrl: 'https://example.test/local-full/256',
+                imageSmallUrl: 'https://example.test/local-thumb/128'
+            })
+        ]);
+    });
+
+    it('keeps full and compact image urls separate for avatar history cards', () => {
+        const items = buildFavoriteAvatarHistoryItems({
+            kind: 'avatar',
+            avatarHistory: [
+                {
+                    id: 'avtr_history',
+                    name: 'History Avatar',
+                    thumbnailImageUrl: 'https://example.test/history-thumb/256',
+                    imageUrl: 'https://example.test/history-full/256'
+                }
+            ],
+            t: (key: string) => key
+        });
+
+        expect(items).toEqual([
+            expect.objectContaining({
+                imageUrl: 'https://example.test/history-full/256',
+                imageSmallUrl: 'https://example.test/history-thumb/128'
             })
         ]);
     });

--- a/src/features/favorites/favoritesPageData.ts
+++ b/src/features/favorites/favoritesPageData.ts
@@ -470,6 +470,10 @@ export function buildFavoriteRemoteItemsByGroup({
             authorName ||
             defaultFavoriteDetailSubtitle(kind, isUnavailable, translate);
 
+        const imageUrl = (displayDetail?.thumbnailImageUrl ||
+            displayDetail?.imageUrl ||
+            '') as string;
+
         itemsByGroup[groupKey].push({
             key: `remote:${groupKey}:${favoriteId}`,
             kind,
@@ -486,11 +490,8 @@ export function buildFavoriteRemoteItemsByGroup({
             authorName,
             description: textValue(displayDetail?.description),
             seedData: displayDetail || null,
-            imageUrl: shrinkImage(
-                displayDetail?.thumbnailImageUrl ||
-                    displayDetail?.imageUrl ||
-                    ''
-            ),
+            imageSmallUrl: shrinkImage(imageUrl),
+            imageUrl,
             isPrivate,
             isUnavailable,
             tags: stringArray(displayDetail?.tags),

--- a/src/features/favorites/favoritesPageData.ts
+++ b/src/features/favorites/favoritesPageData.ts
@@ -5,6 +5,7 @@ import { hasDisplayableEntityDetail } from './favoriteEntityDetails';
 import {
     favoriteGroupType,
     normalizeFavoriteEntityId as normalizeEntityId,
+    resolveFavoriteImage,
     shrinkFavoriteImage as shrinkImage,
     sortFavoriteItems as sortItems
 } from './favoritesItems';
@@ -76,6 +77,15 @@ function firstDisplayableDetail(candidates: unknown[]) {
     return candidates.find((candidate) =>
         hasDisplayableEntityDetail(candidate)
     ) as FavoriteEntityDetail | undefined;
+}
+
+function favoriteImagePair(detail: FavoriteEntityDetail | null | undefined) {
+    const largeImageUrl = resolveFavoriteImage(detail?.imageUrl);
+    const thumbnailImageUrl = resolveFavoriteImage(detail?.thumbnailImageUrl);
+    return {
+        imageUrl: largeImageUrl || thumbnailImageUrl,
+        imageSmallUrl: shrinkImage(thumbnailImageUrl || largeImageUrl)
+    };
 }
 
 function buildRemoteFavoriteGroups(
@@ -470,9 +480,7 @@ export function buildFavoriteRemoteItemsByGroup({
             authorName ||
             defaultFavoriteDetailSubtitle(kind, isUnavailable, translate);
 
-        const imageUrl = (displayDetail?.thumbnailImageUrl ||
-            displayDetail?.imageUrl ||
-            '') as string;
+        const imagePair = favoriteImagePair(displayDetail);
 
         itemsByGroup[groupKey].push({
             key: `remote:${groupKey}:${favoriteId}`,
@@ -490,8 +498,7 @@ export function buildFavoriteRemoteItemsByGroup({
             authorName,
             description: textValue(displayDetail?.description),
             seedData: displayDetail || null,
-            imageSmallUrl: shrinkImage(imageUrl),
-            imageUrl,
+            ...imagePair,
             isPrivate,
             isUnavailable,
             tags: stringArray(displayDetail?.tags),
@@ -578,6 +585,7 @@ export function buildFavoriteLocalItemsByGroup({
                 id: normalizedId
             };
             const playerCount = Number(detail.occupants) || 0;
+            const imagePair = favoriteImagePair(detail);
             return {
                 key: `local:${group.key}:${normalizedId}`,
                 kind,
@@ -592,9 +600,7 @@ export function buildFavoriteLocalItemsByGroup({
                 authorName: textValue(detail.authorName),
                 description: textValue(detail.description),
                 seedData: detail || null,
-                imageUrl: shrinkImage(
-                    detail.thumbnailImageUrl || detail.imageUrl || ''
-                ),
+                ...imagePair,
                 isPrivate: textValue(detail.releaseStatus) === 'private',
                 isUnavailable: false,
                 tags: stringArray(detail.tags),
@@ -626,6 +632,7 @@ export function buildFavoriteAvatarHistoryItems({
 
     return avatarHistory.map((detail, index) => {
         const normalizedId = normalizeEntityId(detail?.id);
+        const imagePair = favoriteImagePair(detail);
         return {
             key: `history:local-history:${normalizedId || index}`,
             kind: 'avatar',
@@ -640,9 +647,7 @@ export function buildFavoriteAvatarHistoryItems({
             authorName: textValue(detail?.authorName),
             description: textValue(detail?.description),
             seedData: detail || null,
-            imageUrl: shrinkImage(
-                detail?.thumbnailImageUrl || detail?.imageUrl || ''
-            ),
+            ...imagePair,
             isPrivate: textValue(detail?.releaseStatus) === 'private',
             isUnavailable: false,
             tags: stringArray(detail?.tags),

--- a/src/features/favorites/favoritesTypes.ts
+++ b/src/features/favorites/favoritesTypes.ts
@@ -25,6 +25,7 @@ export type FavoriteItem = {
     authorName?: string;
     description?: string;
     detailText?: string;
+    imageSmallUrl?: string;
     imageUrl?: string;
     seedData?: unknown;
     isUnavailable?: boolean;


### PR DESCRIPTION
Make the image looks more clear on standard density

---

Before
<img width="1840" height="1119" alt="image" src="https://github.com/user-attachments/assets/2e22610c-48ed-47bd-82ab-e46b6a6797cf" />
<img width="553" height="274" alt="image" src="https://github.com/user-attachments/assets/29992078-f8b7-448e-9357-436dde9e1c36" />

After
<img width="1840" height="1119" alt="image" src="https://github.com/user-attachments/assets/d1ec764e-8856-4cda-b705-b2695bed39d7" />
<img width="557" height="282" alt="image" src="https://github.com/user-attachments/assets/c4843c85-82af-4f34-b3aa-d20e93ab86ff" />

