### PR TITLE
Localize default modal action labels

### DIFF
--- a/src/components/hosts/ModalHost.test.tsx
+++ b/src/components/hosts/ModalHost.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import type { ComponentProps, PropsWithChildren } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key: string) =>
+            ({
+                'dialog.alertdialog.cancel': '取消',
+                'dialog.alertdialog.confirm': '确认',
+                'dialog.alertdialog.ok': '确定',
+                'dialog.tools.label.prompt_value': '请输入内容'
+            })[key] ?? key
+    })
+}));
+
+vi.mock('@/components/dialogs/BoopEmojiDialog', () => ({
+    BoopEmojiDialog: () => null
+}));
+
+vi.mock('@/components/media/FullscreenImageViewer', () => ({
+    FullscreenImageViewer: () => null
+}));
+
+vi.mock('@/state/runtimeStore', () => ({
+    useRuntimeStore: (
+        selector: (state: { auth: { currentUserSnapshot: null } }) => unknown
+    ) => selector({ auth: { currentUserSnapshot: null } })
+}));
+
+vi.mock('@/ui/shadcn/alert-dialog', () => ({
+    AlertDialog: ({ children, open }: PropsWithChildren<{ open: boolean }>) =>
+        open ? <div>{children}</div> : null,
+    AlertDialogContent: ({ children }: PropsWithChildren) => (
+        <section>{children}</section>
+    ),
+    AlertDialogDescription: ({ children }: PropsWithChildren) => (
+        <p>{children}</p>
+    ),
+    AlertDialogFooter: ({ children }: PropsWithChildren) => (
+        <footer>{children}</footer>
+    ),
+    AlertDialogHeader: ({ children }: PropsWithChildren) => (
+        <header>{children}</header>
+    ),
+    AlertDialogTitle: ({ children }: PropsWithChildren) => <h1>{children}</h1>
+}));
+
+vi.mock('@/ui/shadcn/button', () => ({
+    Button: ({ children, ...props }: ComponentProps<'button'>) => (
+        <button {...props}>{children}</button>
+    )
+}));
+
+vi.mock('@/ui/shadcn/dialog', () => ({
+    Dialog: ({ children, open }: PropsWithChildren<{ open: boolean }>) =>
+        open ? <div>{children}</div> : null,
+    DialogContent: ({ children }: PropsWithChildren) => (
+        <section>{children}</section>
+    ),
+    DialogDescription: ({ children }: PropsWithChildren) => <p>{children}</p>,
+    DialogFooter: ({ children }: PropsWithChildren) => (
+        <footer>{children}</footer>
+    ),
+    DialogHeader: ({ children }: PropsWithChildren) => (
+        <header>{children}</header>
+    ),
+    DialogTitle: ({ children }: PropsWithChildren) => <h1>{children}</h1>
+}));
+
+vi.mock('@/ui/shadcn/input', () => ({
+    Input: (props: ComponentProps<'input'>) => <input {...props} />
+}));
+
+vi.mock('@/ui/shadcn/input-otp', () => ({
+    InputOTP: ({ children }: PropsWithChildren) => <div>{children}</div>,
+    InputOTPGroup: ({ children }: PropsWithChildren) => <div>{children}</div>,
+    InputOTPSeparator: () => null,
+    InputOTPSlot: () => null
+}));
+
+vi.mock('@/ui/shadcn/textarea', () => ({
+    Textarea: (props: ComponentProps<'textarea'>) => <textarea {...props} />
+}));
+
+import { useModalStore } from '@/state/modalStore';
+
+import { ModalHost } from './ModalHost';
+
+describe('ModalHost', () => {
+    beforeEach(() => {
+        useModalStore.getState().resetModalState();
+    });
+
+    afterEach(() => {
+        cleanup();
+        useModalStore.getState().resetModalState();
+    });
+
+    it('localizes default prompt actions while preserving custom labels', () => {
+        void useModalStore.getState().prompt({
+            title: '延迟时间',
+            description: '输入延迟时间'
+        });
+
+        const view = render(<ModalHost />);
+
+        expect(screen.getByRole('button', { name: '取消' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: '确认' })).toBeTruthy();
+
+        void useModalStore.getState().prompt({
+            title: '自定义操作',
+            confirmText: '保存',
+            cancelText: '返回'
+        });
+        view.rerender(<ModalHost />);
+
+        expect(screen.getByRole('button', { name: '返回' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: '保存' })).toBeTruthy();
+    });
+});

--- a/src/components/hosts/ModalHost.tsx
+++ b/src/components/hosts/ModalHost.tsx
@@ -130,7 +130,8 @@ export function ModalHost() {
                                 variant="outline"
                                 onClick={handleCancel}
                             >
-                                {alertDialog.cancelText}
+                                {alertDialog.cancelText ||
+                                    t('dialog.alertdialog.cancel')}
                             </Button>
                         ) : null}
                         {alertDialog.alternativeText ? (
@@ -151,7 +152,12 @@ export function ModalHost() {
                             }
                             onClick={handleOk}
                         >
-                            {alertDialog.confirmText}
+                            {alertDialog.confirmText ||
+                                t(
+                                    alertDialog.mode === 'alert'
+                                        ? 'dialog.alertdialog.ok'
+                                        : 'dialog.alertdialog.confirm'
+                                )}
                         </Button>
                     </AlertDialogFooter>
                 </AlertDialogContent>
@@ -198,14 +204,16 @@ export function ModalHost() {
                                 handlePromptCancel(promptDialog.value)
                             }
                         >
-                            {promptDialog.cancelText}
+                            {promptDialog.cancelText ||
+                                t('dialog.alertdialog.cancel')}
                         </Button>
                         <Button
                             type="button"
                             disabled={!promptValueIsValid}
                             onClick={() => handlePromptOk(promptDialog.value)}
                         >
-                            {promptDialog.confirmText}
+                            {promptDialog.confirmText ||
+                                t('dialog.alertdialog.confirm')}
                         </Button>
                     </DialogFooter>
                 </DialogContent>
@@ -291,13 +299,15 @@ export function ModalHost() {
                             variant="outline"
                             onClick={() => handleOtpCancel(otpDialog.value)}
                         >
-                            {otpDialog.cancelText}
+                            {otpDialog.cancelText ||
+                                t('dialog.alertdialog.cancel')}
                         </Button>
                         <Button
                             type="button"
                             onClick={() => handleOtpOk(otpDialog.value)}
                         >
-                            {otpDialog.confirmText}
+                            {otpDialog.confirmText ||
+                                t('dialog.alertdialog.confirm')}
                         </Button>
                     </DialogFooter>
                 </DialogContent>

--- a/src/state/modalStore.ts
+++ b/src/state/modalStore.ts
@@ -105,9 +105,9 @@ const createAlertDialogState = (): AlertDialogState => ({
     mode: 'alert',
     title: '',
     description: '',
-    confirmText: 'OK',
+    confirmText: '',
     alternativeText: '',
-    cancelText: 'Cancel',
+    cancelText: '',
     dismissible: true,
     destructive: false
 });
@@ -117,8 +117,8 @@ const createPromptDialogState = (): PromptDialogState => ({
     title: '',
     description: '',
     value: '',
-    confirmText: 'Confirm',
-    cancelText: 'Cancel',
+    confirmText: '',
+    cancelText: '',
     dismissible: true,
     inputType: 'text',
     inputPattern: null,
@@ -131,8 +131,8 @@ const createOtpDialogState = (): OtpDialogState => ({
     description: '',
     value: '',
     mode: 'totp',
-    confirmText: 'Confirm',
-    cancelText: 'Cancel',
+    confirmText: '',
+    cancelText: '',
     dismissible: true
 });
 


### PR DESCRIPTION
## Summary

- localize default alert, confirm, prompt, and OTP action labels through the existing `dialog.alertdialog` translations
- preserve explicitly supplied custom action labels
- add a regression test for localized defaults and custom overrides

## Root cause

The modal store initialized default action labels with hardcoded English text. As a result, dialogs that did not explicitly provide button labels bypassed the existing translations and displayed `OK`, `Confirm`, or `Cancel` in every locale.

## Impact

Default modal actions now follow the active application language without requiring each caller to provide duplicate labels. Existing custom labels continue to take precedence.

## Validation

- `npm test -- src/components/hosts/ModalHost.test.tsx src/state/modalStore.test.ts`
- `npm run typecheck`
- `npm run lint`
- `oxfmt --check src/components/hosts/ModalHost.tsx src/components/hosts/ModalHost.test.tsx src/state/modalStore.ts`
