### PR TITLE
feat: add SiliconFlow LLM endpoint preset

### DIFF
--- a/src/components/hosts/tools-dialogs/LlmEndpointsPresets.test.ts
+++ b/src/components/hosts/tools-dialogs/LlmEndpointsPresets.test.ts
@@ -29,7 +29,14 @@ describe('LLM endpoint presets', () => {
     it('exposes presets in the agreed order and defaults new drafts to OpenAI', () => {
         expect(
             LLM_ENDPOINT_PROVIDER_PRESETS.map((preset) => preset.id)
-        ).toEqual(['openai', 'openrouter', 'gemini', 'deepseek', 'xai']);
+        ).toEqual([
+            'openai',
+            'openrouter',
+            'gemini',
+            'deepseek',
+            'xai',
+            'siliconflow'
+        ]);
         expect(DEFAULT_LLM_ENDPOINT_PROVIDER_ID).toBe('openai');
         expect(createEmptyLlmEndpointDraft()).toMatchObject({
             providerId: 'openai',
@@ -92,6 +99,17 @@ describe('LLM endpoint presets', () => {
             providerId: 'openrouter',
             name: 'OpenRouter',
             baseUrl: 'https://openrouter.ai/api/v1',
+            apiKey: 'sk-existing',
+            clearKey: true,
+            modelsText: '',
+            detectedModelReasoning: null
+        });
+        expect(applyLlmEndpointProviderPreset(draft(), 'siliconflow')).toEqual({
+            id: 'ep_1',
+            savedBaseUrl: 'https://example.test/v1',
+            providerId: 'siliconflow',
+            name: 'SiliconFlow',
+            baseUrl: 'https://api.siliconflow.cn/v1',
             apiKey: 'sk-existing',
             clearKey: true,
             modelsText: '',

--- a/src/components/hosts/tools-dialogs/llmEndpointPresets.ts
+++ b/src/components/hosts/tools-dialogs/llmEndpointPresets.ts
@@ -9,6 +9,7 @@ export type LlmEndpointProviderId =
     | 'gemini'
     | 'deepseek'
     | 'xai'
+    | 'siliconflow'
     | typeof CUSTOM_LLM_ENDPOINT_PROVIDER_ID;
 
 export type LlmEndpointProviderPreset = {
@@ -60,6 +61,12 @@ export const LLM_ENDPOINT_PROVIDER_PRESETS: LlmEndpointProviderPreset[] = [
         name: 'xAI',
         labelKey: 'view.tools.llm_endpoints.presets.xai',
         baseUrl: 'https://api.x.ai/v1'
+    },
+    {
+        id: 'siliconflow',
+        name: 'SiliconFlow',
+        labelKey: 'view.tools.llm_endpoints.presets.siliconflow',
+        baseUrl: 'https://api.siliconflow.cn/v1'
     }
 ];
 

--- a/src/localization/cs.json
+++ b/src/localization/cs.json
@@ -1921,7 +1921,8 @@
                     "openrouter": "OpenRouter",
                     "gemini": "Google Gemini",
                     "deepseek": "DeepSeek",
-                    "xai": "xAI"
+                    "xai": "xAI (Grok)",
+                    "siliconflow": "SiliconFlow"
                 },
                 "name": "Název",
                 "base_url": "Základní URL",

--- a/src/localization/de.json
+++ b/src/localization/de.json
@@ -1919,7 +1919,8 @@
                     "openrouter": "OpenRouter",
                     "gemini": "Google Gemini",
                     "deepseek": "DeepSeek",
-                    "xai": "xAI"
+                    "xai": "xAI (Grok)",
+                    "siliconflow": "SiliconFlow"
                 },
                 "name": "Name",
                 "base_url": "Basis-URL",

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -1919,7 +1919,8 @@
                     "openrouter": "OpenRouter",
                     "gemini": "Google Gemini",
                     "deepseek": "DeepSeek",
-                    "xai": "xAI"
+                    "xai": "xAI (Grok)",
+                    "siliconflow": "SiliconFlow"
                 },
                 "name": "Name",
                 "base_url": "Base URL",

--- a/src/localization/es.json
+++ b/src/localization/es.json
@@ -1919,7 +1919,8 @@
                     "openrouter": "OpenRouter",
                     "gemini": "Google Gemini",
                     "deepseek": "DeepSeek",
-                    "xai": "xAI"
+                    "xai": "xAI (Grok)",
+                    "siliconflow": "SiliconFlow"
                 },
                 "name": "Nombre",
                 "base_url": "URL base",

--- a/src/localization/fr.json
+++ b/src/localization/fr.json
@@ -1919,7 +1919,8 @@
                     "openrouter": "OpenRouter",
                     "gemini": "Google Gemini",
                     "deepseek": "DeepSeek",
-                    "xai": "xAI"
+                    "xai": "xAI (Grok)",
+                    "siliconflow": "SiliconFlow"
                 },
                 "name": "Nom",
                 "base_url": "URL de base",

--- a/src/localization/ja.json
+++ b/src/localization/ja.json
@@ -1915,7 +1915,8 @@
                     "openrouter": "OpenRouter",
                     "gemini": "Google Gemini",
                     "deepseek": "DeepSeek",
-                    "xai": "xAI"
+                    "xai": "xAI (Grok)",
+                    "siliconflow": "SiliconFlow"
                 },
                 "name": "名前",
                 "base_url": "Base URL",

--- a/src/localization/ko.json
+++ b/src/localization/ko.json
@@ -1890,7 +1890,8 @@
                     "openrouter": "OpenRouter",
                     "gemini": "Google Gemini",
                     "deepseek": "DeepSeek",
-                    "xai": "xAI"
+                    "xai": "xAI (Grok)",
+                    "siliconflow": "SiliconFlow"
                 },
                 "name": "이름",
                 "base_url": "Base URL",

--- a/src/localization/pt.json
+++ b/src/localization/pt.json
@@ -1919,7 +1919,8 @@
                     "openrouter": "OpenRouter",
                     "gemini": "Google Gemini",
                     "deepseek": "DeepSeek",
-                    "xai": "xAI"
+                    "xai": "xAI (Grok)",
+                    "siliconflow": "SiliconFlow"
                 },
                 "name": "Nome",
                 "base_url": "URL base",

--- a/src/localization/ru.json
+++ b/src/localization/ru.json
@@ -1921,7 +1921,8 @@
                     "openrouter": "OpenRouter",
                     "gemini": "Google Gemini",
                     "deepseek": "DeepSeek",
-                    "xai": "xAI"
+                    "xai": "xAI (Grok)",
+                    "siliconflow": "SiliconFlow"
                 },
                 "name": "Имя",
                 "base_url": "Базовый URL",

--- a/src/localization/zh-CN.json
+++ b/src/localization/zh-CN.json
@@ -1919,7 +1919,8 @@
                     "openrouter": "OpenRouter",
                     "gemini": "Google Gemini",
                     "deepseek": "DeepSeek",
-                    "xai": "xAI"
+                    "xai": "xAI (Grok)",
+                    "siliconflow": "硅基流动"
                 },
                 "name": "名称",
                 "base_url": "Base URL",

--- a/src/localization/zh-TW.json
+++ b/src/localization/zh-TW.json
@@ -1919,7 +1919,8 @@
                     "openrouter": "OpenRouter",
                     "gemini": "Google Gemini",
                     "deepseek": "DeepSeek",
-                    "xai": "xAI"
+                    "xai": "xAI (Grok)",
+                    "siliconflow": "矽基流動"
                 },
                 "name": "名稱",
                 "base_url": "基礎網址",


### PR DESCRIPTION
## Summary

- add SiliconFlow as the final OpenAI-compatible LLM endpoint preset
- use `https://api.siliconflow.cn/v1` as the preset base URL
- localize the SiliconFlow label for Simplified and Traditional Chinese
- show the xAI preset as `xAI (Grok)` for better recognition
- cover the new preset and ordering in the endpoint preset tests

## Why

SiliconFlow exposes an OpenAI-compatible API, so users can configure it without entering the endpoint manually. Its localized Chinese name is more recognizable to users in those locales, while other locales retain the SiliconFlow brand name.

## User impact

Users can select SiliconFlow directly from the LLM endpoint preset list and still customize or detect models through the existing flow.

## Validation

- `npm test -- src/components/hosts/tools-dialogs/LlmEndpointsPresets.test.ts`
- `npm exec -- oxfmt --check src/components/hosts/tools-dialogs/llmEndpointPresets.ts src/components/hosts/tools-dialogs/LlmEndpointsPresets.test.ts src/localization/*.json`
- `npm run typecheck`
- `git diff --check`
