### PR TITLE
fix(user-dialog): merge display name history sources

### DIFF
--- a/src/components/dialogs/user-dialog/useUserDialogSupplementalData.ts
+++ b/src/components/dialogs/user-dialog/useUserDialogSupplementalData.ts
@@ -16,6 +16,7 @@ import {
     isSameLocationTag,
     resolvePresenceLocation
 } from './userDialogContentHelpers';
+import { replacePreviousDisplayNameSource } from './userDialogRows';
 import { normalizeUserId } from './userProfileFields';
 import type { UserDialogProfileRecord } from './useUserDialogProfileResource';
 
@@ -329,28 +330,23 @@ export function useUserDialogSupplementalData({
                 if (!active) {
                     return;
                 }
-                const previousDisplayNames =
-                    stats?.previousDisplayNames instanceof Map
-                        ? Array.from(
-                              stats.previousDisplayNames,
-                              ([displayName, updated_at]) => ({
-                                  displayName: normalizeUserId(displayName),
-                                  updated_at: normalizeUserId(updated_at)
-                              })
-                          )
-                        : Array.isArray(stats?.previousDisplayNames)
-                          ? stats.previousDisplayNames
-                          : [];
                 const nextStats = {
                     timeSpent: Number(stats?.timeSpent) || 0,
                     lastSeen: normalizeUserId(stats?.lastSeen),
-                    joinCount: Number(stats?.joinCount) || 0,
-                    previousDisplayNames
+                    joinCount: Number(stats?.joinCount) || 0
                 };
                 setUserStatsForTarget((current) => {
+                    const previousDisplayNames =
+                        replacePreviousDisplayNameSource(
+                            profile.displayName || profile.username,
+                            current.previousDisplayNameSources,
+                            'gameLog',
+                            stats?.previousDisplayNames
+                        );
                     const mergedStats = {
                         ...current,
-                        ...nextStats
+                        ...nextStats,
+                        ...previousDisplayNames
                     };
                     return mergedStats;
                 });
@@ -431,10 +427,24 @@ export function useUserDialogSupplementalData({
         const targetUserId = normalizeUserId(profile?.id);
 
         if (!ownerUserId || !targetUserId || isTargetCurrentUser) {
-            setUserStatsForTarget((current) => ({
-                ...current,
-                friendedAt: ''
-            }));
+            setUserStatsForTarget((current) => {
+                if (!isTargetCurrentUser) {
+                    return {
+                        ...current,
+                        friendedAt: ''
+                    };
+                }
+                return {
+                    ...current,
+                    friendedAt: '',
+                    ...replacePreviousDisplayNameSource(
+                        profile?.displayName || profile?.username,
+                        current.previousDisplayNameSources,
+                        'friendLog',
+                        []
+                    )
+                };
+            });
             return () => {
                 active = false;
             };
@@ -443,7 +453,7 @@ export function useUserDialogSupplementalData({
         friendLogHistoryRepository
             .getFriendLogHistory(ownerUserId, {
                 targetUserId,
-                types: ['Friend', 'Unfriend']
+                types: ['Friend', 'Unfriend', 'DisplayName']
             })
             .then((rows) => {
                 if (!active) {
@@ -452,9 +462,21 @@ export function useUserDialogSupplementalData({
                 const friendedAt = normalizeUserId(
                     resolveFriendedAtFromHistoryRows(rows)
                 );
+                const friendLogPreviousDisplayNames = rows
+                    .filter((row) => row.type === 'DisplayName')
+                    .map((row) => ({
+                        displayName: row.previousDisplayName,
+                        updated_at: row.created_at
+                    }));
                 setUserStatsForTarget((current) => ({
                     ...current,
-                    friendedAt
+                    friendedAt,
+                    ...replacePreviousDisplayNameSource(
+                        profile?.displayName || profile?.username,
+                        current.previousDisplayNameSources,
+                        'friendLog',
+                        friendLogPreviousDisplayNames
+                    )
                 }));
             })
             .catch(() => {});
@@ -468,7 +490,9 @@ export function useUserDialogSupplementalData({
         currentUserSnapshot?.userId,
         currentUserSnapshot?.user_id,
         isTargetCurrentUser,
+        profile?.displayName,
         profile?.id,
+        profile?.username,
         reloadToken,
         setUserStatsForTarget,
         targetKey

--- a/src/components/dialogs/user-dialog/userDialogCache.test.ts
+++ b/src/components/dialogs/user-dialog/userDialogCache.test.ts
@@ -66,11 +66,17 @@ describe('userDialogCache', () => {
             timeSpent: '2000',
             lastSeen: '2026-01-02T03:04:05.000Z',
             joinCount: '3',
-            previousDisplayNames: [{ displayName: 'Original' }]
+            previousDisplayNames: [{ displayName: 'Original' }],
+            previousDisplayNameSources: {
+                friendLog: [{ displayName: 'Friend Log Name' }],
+                gameLog: [{ displayName: 'Game Log Name' }]
+            }
         });
 
         const firstRead = readCachedUserStats(key);
         firstRead.previousDisplayNames[0].displayName = 'Mutated';
+        firstRead.previousDisplayNameSources!.friendLog[0].displayName =
+            'Mutated';
         firstRead.timeSpent = 0;
 
         expect(readCachedUserStats(key)).toEqual({
@@ -78,7 +84,11 @@ describe('userDialogCache', () => {
             lastSeen: '2026-01-02T03:04:05.000Z',
             friendedAt: '',
             joinCount: 3,
-            previousDisplayNames: [{ displayName: 'Original' }]
+            previousDisplayNames: [{ displayName: 'Original' }],
+            previousDisplayNameSources: {
+                friendLog: [{ displayName: 'Friend Log Name' }],
+                gameLog: [{ displayName: 'Game Log Name' }]
+            }
         });
     });
 

--- a/src/components/dialogs/user-dialog/userDialogCache.ts
+++ b/src/components/dialogs/user-dialog/userDialogCache.ts
@@ -1,13 +1,22 @@
 import { normalizeUserId } from './userProfileFields';
+
+export type UserDialogPreviousDisplayName = {
+    displayName: string;
+    updated_at?: string;
+};
+
+export type UserDialogPreviousDisplayNameSources = {
+    friendLog: UserDialogPreviousDisplayName[];
+    gameLog: UserDialogPreviousDisplayName[];
+};
+
 export type UserDialogStats = {
     timeSpent: number;
     lastSeen: string;
     friendedAt: string;
     joinCount: number;
-    previousDisplayNames: Array<{
-        displayName: string;
-        updated_at?: string;
-    }>;
+    previousDisplayNames: UserDialogPreviousDisplayName[];
+    previousDisplayNameSources?: UserDialogPreviousDisplayNameSources;
 };
 
 function record(value: unknown): Record<string, unknown> {
@@ -36,10 +45,11 @@ export function dialogTargetKey(endpoint: unknown, userId: unknown) {
     return `${normalizeUserId(endpoint)}:${normalizedUserId}`;
 }
 
-function cloneUserStats(source: unknown = DEFAULT_USER_STATS): UserDialogStats {
-    const stats = record(source);
-    const previousDisplayNames = Array.isArray(stats.previousDisplayNames)
-        ? stats.previousDisplayNames.map((entry) => {
+function clonePreviousDisplayNames(
+    source: unknown
+): UserDialogPreviousDisplayName[] {
+    return Array.isArray(source)
+        ? source.map((entry) => {
               const row = record(entry);
               return {
                   displayName: normalizeUserId(row.displayName),
@@ -49,12 +59,35 @@ function cloneUserStats(source: unknown = DEFAULT_USER_STATS): UserDialogStats {
               };
           })
         : [];
+}
+
+function cloneUserStats(source: unknown = DEFAULT_USER_STATS): UserDialogStats {
+    const stats = record(source);
+    const previousDisplayNames = clonePreviousDisplayNames(
+        stats.previousDisplayNames
+    );
+    const rawPreviousDisplayNameSources = record(
+        stats.previousDisplayNameSources
+    );
+    const previousDisplayNameSources =
+        Object.keys(rawPreviousDisplayNameSources).length > 0
+            ? {
+                  friendLog: clonePreviousDisplayNames(
+                      rawPreviousDisplayNameSources.friendLog
+                  ),
+                  gameLog: clonePreviousDisplayNames(
+                      rawPreviousDisplayNameSources.gameLog
+                  )
+              }
+            : undefined;
+
     return {
         timeSpent: Number(stats?.timeSpent) || 0,
         lastSeen: normalizeUserId(stats.lastSeen),
         friendedAt: normalizeUserId(stats.friendedAt),
         joinCount: Number(stats?.joinCount) || 0,
-        previousDisplayNames
+        previousDisplayNames,
+        ...(previousDisplayNameSources ? { previousDisplayNameSources } : {})
     };
 }
 

--- a/src/components/dialogs/user-dialog/userDialogRows.test.ts
+++ b/src/components/dialogs/user-dialog/userDialogRows.test.ts
@@ -17,8 +17,10 @@ import {
     groupDisplayName,
     hydrateMutualFriendRows,
     isOfflineLikeValue,
+    mergePreviousDisplayNames,
     normalizeLanguageRows,
     normalizePreviousDisplayNames,
+    replacePreviousDisplayNameSource,
     resolveStatusStateText,
     resolveTabValue,
     sortAvatarRows,
@@ -257,6 +259,81 @@ describe('userDialogRows', () => {
             { displayName: 'Legacy Name', updated_at: '' },
             { displayName: 'Past Name', updated_at: '2025-01-01' }
         ]);
+    });
+
+    it('merges friend-log rename history and excludes a restored current name', () => {
+        expect(
+            mergePreviousDisplayNames(
+                'Original Name',
+                new Map([
+                    ['Observed Name', '2026-01-02T00:00:00.000Z'],
+                    ['Original Name', '2026-01-01T00:00:00.000Z']
+                ]),
+                [
+                    {
+                        displayName: 'Temporary Name',
+                        updated_at: '2026-01-04T00:00:00.000Z'
+                    },
+                    {
+                        displayName: 'Original Name',
+                        updated_at: '2026-01-03T00:00:00.000Z'
+                    },
+                    {
+                        displayName: 'Observed Name',
+                        updated_at: '2026-01-05T00:00:00.000Z'
+                    }
+                ]
+            )
+        ).toEqual([
+            {
+                displayName: 'Observed Name',
+                updated_at: '2026-01-05T00:00:00.000Z'
+            },
+            {
+                displayName: 'Temporary Name',
+                updated_at: '2026-01-04T00:00:00.000Z'
+            }
+        ]);
+    });
+
+    it('replaces one refreshed name source without retaining rows deleted from it', () => {
+        const initial = replacePreviousDisplayNameSource(
+            'Current Name',
+            {
+                gameLog: [
+                    {
+                        displayName: 'Observed Name',
+                        updated_at: '2026-01-02T00:00:00.000Z'
+                    }
+                ],
+                friendLog: [
+                    {
+                        displayName: 'Deleted Rename',
+                        updated_at: '2026-01-03T00:00:00.000Z'
+                    }
+                ]
+            },
+            'friendLog',
+            []
+        );
+
+        expect(initial).toEqual({
+            previousDisplayNames: [
+                {
+                    displayName: 'Observed Name',
+                    updated_at: '2026-01-02T00:00:00.000Z'
+                }
+            ],
+            previousDisplayNameSources: {
+                friendLog: [],
+                gameLog: [
+                    {
+                        displayName: 'Observed Name',
+                        updated_at: '2026-01-02T00:00:00.000Z'
+                    }
+                ]
+            }
+        });
     });
 
     it('uses readable fallback text for empty stats and unavailable locations', () => {

--- a/src/components/dialogs/user-dialog/userDialogRows.ts
+++ b/src/components/dialogs/user-dialog/userDialogRows.ts
@@ -41,10 +41,17 @@ type LanguageRow = {
     value: string;
 };
 
-type PreviousDisplayNameRow = {
+export type PreviousDisplayNameRow = {
     displayName: string;
-    updated_at: unknown;
+    updated_at?: string;
 };
+
+export type PreviousDisplayNameSources = {
+    friendLog: PreviousDisplayNameRow[];
+    gameLog: PreviousDisplayNameRow[];
+};
+
+export type PreviousDisplayNameSource = keyof PreviousDisplayNameSources;
 
 type TranslateFn = (key: string) => string;
 
@@ -291,11 +298,65 @@ export function normalizePreviousDisplayNames(value: unknown) {
             const record = isRecord(entry) ? entry : {};
             return {
                 displayName: normalizedText(record.displayName || record.name),
-                updated_at:
+                updated_at: normalizedText(
                     record.updated_at || record.updatedAt || record.date || ''
+                )
             };
         })
         .filter((entry) => entry.displayName);
+}
+
+export function mergePreviousDisplayNames(
+    currentDisplayName: unknown,
+    ...sources: unknown[]
+) {
+    const currentName = normalizedText(currentDisplayName);
+    const namesByDisplayName = new Map<string, PreviousDisplayNameRow>();
+
+    for (const source of sources) {
+        for (const entry of normalizePreviousDisplayNames(source)) {
+            if (entry.displayName === currentName) {
+                continue;
+            }
+
+            const existing = namesByDisplayName.get(entry.displayName);
+            if (
+                !existing ||
+                normalizedText(entry.updated_at) >
+                    normalizedText(existing.updated_at)
+            ) {
+                namesByDisplayName.set(entry.displayName, entry);
+            }
+        }
+    }
+
+    return Array.from(namesByDisplayName.values()).sort((left, right) =>
+        normalizedText(right.updated_at).localeCompare(
+            normalizedText(left.updated_at)
+        )
+    );
+}
+
+export function replacePreviousDisplayNameSource(
+    currentDisplayName: unknown,
+    currentSources: Partial<PreviousDisplayNameSources> | null | undefined,
+    source: PreviousDisplayNameSource,
+    rows: unknown
+) {
+    const previousDisplayNameSources: PreviousDisplayNameSources = {
+        friendLog: normalizePreviousDisplayNames(currentSources?.friendLog),
+        gameLog: normalizePreviousDisplayNames(currentSources?.gameLog),
+        [source]: mergePreviousDisplayNames(currentDisplayName, rows)
+    };
+
+    return {
+        previousDisplayNames: mergePreviousDisplayNames(
+            currentDisplayName,
+            previousDisplayNameSources.friendLog,
+            previousDisplayNameSources.gameLog
+        ),
+        previousDisplayNameSources
+    };
 }
 
 export function userIdForRow(row: UserDialogRow | null | undefined) {

--- a/src/components/dialogs/user-dialog/userDialogViewData.test.ts
+++ b/src/components/dialogs/user-dialog/userDialogViewData.test.ts
@@ -230,10 +230,11 @@ describe('userDialogViewData', () => {
         });
 
         expect(summary.previousDisplayNames).toEqual([
-            { displayName: 'Old Name', updated_at: '2026-01-02T03:04:05' }
+            { displayName: 'Old Name', updated_at: '2026-01-02T03:04:05' },
+            { displayName: 'Profile Name', updated_at: '' }
         ]);
         expect(summary.previousDisplayNamesTitle).toBe(
-            'Old Name - 2026-01-02 03:04:05'
+            'Old Name - 2026-01-02 03:04:05\nProfile Name'
         );
         expect(summary.statusStateText).toBe('active / join me');
         expect(
@@ -254,5 +255,51 @@ describe('userDialogViewData', () => {
         expect(summary.mutualFriendCount).toBe(4);
         expect(summary.friendNumber).toBe(42);
         expect(summary.presenceActivityAt).toBe('2026-01-03T04:05:06');
+    });
+
+    it('merges current-user API history with locally observed names', () => {
+        const summary = buildUserDialogProfileSummary({
+            profile: {
+                id: 'usr_me',
+                displayName: 'Current Name',
+                pastDisplayNames: [
+                    {
+                        displayName: 'API Recent Name',
+                        updated_at: '2026-07-20T15:02:17.251Z'
+                    },
+                    {
+                        displayName: 'API Older Name',
+                        updated_at: '2025-10-20T16:34:53.541Z'
+                    },
+                    {
+                        displayName: 'Current Name',
+                        updated_at: '2026-07-21T00:00:00.000Z'
+                    }
+                ]
+            },
+            userStats: {
+                previousDisplayNames: [
+                    {
+                        displayName: 'API Recent Name',
+                        updated_at: '2026-07-19T00:00:00.000Z'
+                    }
+                ]
+            },
+            sortedProfileGroups: [],
+            isCurrentUser: true,
+            vrchatConfigConstants: {},
+            currentUserSnapshot: null
+        });
+
+        expect(summary.previousDisplayNames).toEqual([
+            {
+                displayName: 'API Recent Name',
+                updated_at: '2026-07-20T15:02:17.251Z'
+            },
+            {
+                displayName: 'API Older Name',
+                updated_at: '2025-10-20T16:34:53.541Z'
+            }
+        ]);
     });
 });

--- a/src/components/dialogs/user-dialog/userDialogViewData.test.ts
+++ b/src/components/dialogs/user-dialog/userDialogViewData.test.ts
@@ -261,7 +261,20 @@ describe('userDialogViewData', () => {
         const summary = buildUserDialogProfileSummary({
             profile: {
                 id: 'usr_me',
-                displayName: 'Current Name',
+                displayName: 'Current Name'
+            },
+            userStats: {
+                previousDisplayNames: [
+                    {
+                        displayName: 'API Recent Name',
+                        updated_at: '2026-07-19T00:00:00.000Z'
+                    }
+                ]
+            },
+            sortedProfileGroups: [],
+            isCurrentUser: true,
+            vrchatConfigConstants: {},
+            currentUserSnapshot: {
                 pastDisplayNames: [
                     {
                         displayName: 'API Recent Name',
@@ -276,19 +289,7 @@ describe('userDialogViewData', () => {
                         updated_at: '2026-07-21T00:00:00.000Z'
                     }
                 ]
-            },
-            userStats: {
-                previousDisplayNames: [
-                    {
-                        displayName: 'API Recent Name',
-                        updated_at: '2026-07-19T00:00:00.000Z'
-                    }
-                ]
-            },
-            sortedProfileGroups: [],
-            isCurrentUser: true,
-            vrchatConfigConstants: {},
-            currentUserSnapshot: null
+            }
         });
 
         expect(summary.previousDisplayNames).toEqual([

--- a/src/components/dialogs/user-dialog/userDialogViewData.ts
+++ b/src/components/dialogs/user-dialog/userDialogViewData.ts
@@ -349,6 +349,7 @@ export function buildUserDialogProfileSummary({
         profile.displayName || profile.username,
         profile.previousDisplayNames,
         profile.pastDisplayNames,
+        isCurrentUser ? currentUserSnapshot?.pastDisplayNames : null,
         statsPreviousDisplayNames
     );
     const previousDisplayNamesTitle = previousDisplayNames

--- a/src/components/dialogs/user-dialog/userDialogViewData.ts
+++ b/src/components/dialogs/user-dialog/userDialogViewData.ts
@@ -9,7 +9,7 @@ import {
     formatCountText,
     formatStatsDate,
     hydrateMutualFriendRows,
-    normalizePreviousDisplayNames,
+    mergePreviousDisplayNames,
     normalizedText,
     resolveStatusStateText,
     sortAvatarRows,
@@ -345,10 +345,11 @@ export function buildUserDialogProfileSummary({
     )
         ? userStats.previousDisplayNames
         : [];
-    const previousDisplayNames = normalizePreviousDisplayNames(
-        statsPreviousDisplayNames.length
-            ? statsPreviousDisplayNames
-            : profile.previousDisplayNames || profile.pastDisplayNames
+    const previousDisplayNames = mergePreviousDisplayNames(
+        profile.displayName || profile.username,
+        profile.previousDisplayNames,
+        profile.pastDisplayNames,
+        statsPreviousDisplayNames
     );
     const previousDisplayNamesTitle = previousDisplayNames
         .map((entry) =>


### PR DESCRIPTION
## Summary

- merge previous display names from the game log, friend log, and VRChat profile history
- keep game-log and friend-log results as independent snapshots before rebuilding the merged history
- prefer the newest timestamp when the same name appears in multiple sources and exclude the current display name
- add regression coverage for API fallback, source replacement, deduplication, and cache isolation

## Root cause

The user dialog only exposed the game-log-derived name history in some paths. Explicit rename entries from the friend log and `pastDisplayNames` returned by the VRChat profile API could therefore be absent from the profile card.

The first merge implementation also fed the previously merged result back into later refreshes. That avoided asynchronous source updates overwriting each other, but it could retain a name after the originating log entry had been removed.

## Impact

Profile cards now show the available display-name history consistently. Each successful source refresh replaces only that source, an empty successful result clears stale entries, and a failed query preserves the last known snapshot.

## Validation

- `npm.cmd test` — 314 test files, 1600 tests passed
- `npm.cmd run typecheck`
- `npm.cmd run lint`
- `npm.cmd run format:check`
