### PR TITLE
fix(theme): restore system theme synchronization

### DIFF
--- a/src/services/themeService.test.ts
+++ b/src/services/themeService.test.ts
@@ -18,6 +18,30 @@ import {
     supportsConfigurableCjkFontPack
 } from './themeService';
 
+function stubThemeEnvironment(prefersDark: () => boolean) {
+    const toggleDarkClass = vi.fn();
+    const setRootAttribute = vi.fn();
+
+    vi.stubGlobal('window', {
+        matchMedia: vi.fn(() => ({
+            get matches() {
+                return prefersDark();
+            }
+        }))
+    });
+    vi.stubGlobal('document', {
+        documentElement: {
+            classList: {
+                toggle: toggleDarkClass
+            },
+            hasAttribute: vi.fn(() => false),
+            setAttribute: setRootAttribute
+        }
+    });
+
+    return { toggleDarkClass, setRootAttribute };
+}
+
 describe('themeService theme mode', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -30,30 +54,15 @@ describe('themeService theme mode', () => {
 
     it('releases a forced native theme before resolving system mode', async () => {
         let nativeTheme: 'dark' | 'system' = 'dark';
-        const toggleDarkClass = vi.fn();
-        const setRootAttribute = vi.fn();
+        const { toggleDarkClass, setRootAttribute } = stubThemeEnvironment(
+            () => nativeTheme === 'dark'
+        );
 
         mocks.appChangeTheme.mockImplementation(async (value: number) => {
             if (value === -1) {
                 nativeTheme = 'system';
             }
             return null;
-        });
-        vi.stubGlobal('window', {
-            matchMedia: vi.fn(() => ({
-                get matches() {
-                    return nativeTheme === 'dark';
-                }
-            }))
-        });
-        vi.stubGlobal('document', {
-            documentElement: {
-                classList: {
-                    toggle: toggleDarkClass
-                },
-                hasAttribute: vi.fn(() => false),
-                setAttribute: setRootAttribute
-            }
         });
         useShellStore.setState({ themeMode: 'dark' });
 
@@ -63,6 +72,33 @@ describe('themeService theme mode', () => {
         expect(toggleDarkClass).toHaveBeenCalledWith('dark', false);
         expect(setRootAttribute).toHaveBeenCalledWith('data-theme', 'light');
         expect(useShellStore.getState().themeMode).toBe('system');
+    });
+
+    it('keeps the latest explicit theme while system sync is pending', async () => {
+        let releaseSystemTheme: (() => void) | undefined;
+        const { toggleDarkClass } = stubThemeEnvironment(() => false);
+
+        mocks.appChangeTheme.mockImplementation((value: number) => {
+            if (value === -1) {
+                return new Promise<null>((resolve) => {
+                    releaseSystemTheme = () => resolve(null);
+                });
+            }
+            return Promise.resolve(null);
+        });
+        useShellStore.setState({ themeMode: 'light' });
+
+        const pendingSystemTheme = applyThemeMode('system');
+        await vi.waitFor(() =>
+            expect(mocks.appChangeTheme).toHaveBeenCalledWith(-1)
+        );
+        const pendingDarkTheme = applyThemeMode('dark');
+        releaseSystemTheme?.();
+        await Promise.all([pendingSystemTheme, pendingDarkTheme]);
+
+        expect(mocks.appChangeTheme).toHaveBeenLastCalledWith(1);
+        expect(useShellStore.getState().themeMode).toBe('dark');
+        expect(toggleDarkClass).toHaveBeenLastCalledWith('dark', true);
     });
 });
 

--- a/src/services/themeService.test.ts
+++ b/src/services/themeService.test.ts
@@ -1,9 +1,70 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    appChangeTheme: vi.fn()
+}));
+
+vi.mock('@/platform/tauri/bindings', () => ({
+    commands: {
+        appChangeTheme: mocks.appChangeTheme
+    }
+}));
+
+import { useShellStore } from '@/state/shellStore';
 
 import {
+    applyThemeMode,
     resolveAppCjkFontPackForLocale,
     supportsConfigurableCjkFontPack
 } from './themeService';
+
+describe('themeService theme mode', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        useShellStore.setState({ themeMode: 'system' });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('releases a forced native theme before resolving system mode', async () => {
+        let nativeTheme: 'dark' | 'system' = 'dark';
+        const toggleDarkClass = vi.fn();
+        const setRootAttribute = vi.fn();
+
+        mocks.appChangeTheme.mockImplementation(async (value: number) => {
+            if (value === -1) {
+                nativeTheme = 'system';
+            }
+            return null;
+        });
+        vi.stubGlobal('window', {
+            matchMedia: vi.fn(() => ({
+                get matches() {
+                    return nativeTheme === 'dark';
+                }
+            }))
+        });
+        vi.stubGlobal('document', {
+            documentElement: {
+                classList: {
+                    toggle: toggleDarkClass
+                },
+                hasAttribute: vi.fn(() => false),
+                setAttribute: setRootAttribute
+            }
+        });
+        useShellStore.setState({ themeMode: 'dark' });
+
+        await applyThemeMode('system');
+
+        expect(mocks.appChangeTheme).toHaveBeenCalledWith(-1);
+        expect(toggleDarkClass).toHaveBeenCalledWith('dark', false);
+        expect(setRootAttribute).toHaveBeenCalledWith('data-theme', 'light');
+        expect(useShellStore.getState().themeMode).toBe('system');
+    });
+});
 
 describe('themeService CJK font locale routing', () => {
     it('allows configurable CJK font packs for core CJK locales', () => {

--- a/src/services/themeService.ts
+++ b/src/services/themeService.ts
@@ -18,6 +18,11 @@ type AppFontPreferenceInput = {
 };
 
 const VALID_THEME_MODES = new Set<ThemeMode>(['light', 'dark', 'system']);
+const NATIVE_THEME_VALUES: Readonly<Record<ThemeMode, number>> = Object.freeze({
+    system: -1,
+    light: 0,
+    dark: 1
+});
 const VALID_THEME_COLORS = new Set<string>(Object.keys(THEME_COLOR_CONFIG));
 export const DEFAULT_ZOOM_LEVEL = 100;
 export const MIN_ZOOM_LEVEL = 30;
@@ -491,15 +496,19 @@ export function applyAppFontPreferences({
 }
 
 export async function syncNativeTheme(themeMode: unknown): Promise<void> {
-    const resolvedTheme = getResolvedThemeMode(themeMode);
-    const nativeTheme = resolvedTheme === 'dark' ? 1 : 0;
+    const normalized = resolveEffectiveThemeMode(themeMode);
 
-    await commands.appChangeTheme(nativeTheme);
+    await commands.appChangeTheme(NATIVE_THEME_VALUES[normalized]);
 }
 
 export async function applyThemeMode(themeMode: unknown): Promise<void> {
     const normalized = resolveThemeMode(themeMode);
     const effectiveThemeMode = resolveEffectiveThemeMode(normalized);
+
+    if (effectiveThemeMode === 'system') {
+        await syncNativeTheme(effectiveThemeMode);
+    }
+
     const resolvedTheme = getResolvedThemeMode(effectiveThemeMode);
     const shouldUseDarkClass = resolvedTheme === 'dark';
 
@@ -507,7 +516,9 @@ export async function applyThemeMode(themeMode: unknown): Promise<void> {
     document.documentElement.setAttribute('data-theme', resolvedTheme);
 
     useShellStore.getState().setThemeMode(effectiveThemeMode);
-    await syncNativeTheme(effectiveThemeMode);
+    if (effectiveThemeMode !== 'system') {
+        await syncNativeTheme(effectiveThemeMode);
+    }
 }
 
 export async function setCommunityThemeAppearanceControl(

--- a/src/services/themeService.ts
+++ b/src/services/themeService.ts
@@ -23,6 +23,8 @@ const NATIVE_THEME_VALUES: Readonly<Record<ThemeMode, number>> = Object.freeze({
     light: 0,
     dark: 1
 });
+let nativeThemeSyncQueue: Promise<void> = Promise.resolve();
+let themeApplySequence = 0;
 const VALID_THEME_COLORS = new Set<string>(Object.keys(THEME_COLOR_CONFIG));
 export const DEFAULT_ZOOM_LEVEL = 100;
 export const MIN_ZOOM_LEVEL = 30;
@@ -495,18 +497,26 @@ export function applyAppFontPreferences({
     };
 }
 
-export async function syncNativeTheme(themeMode: unknown): Promise<void> {
+export function syncNativeTheme(themeMode: unknown): Promise<void> {
     const normalized = resolveEffectiveThemeMode(themeMode);
+    const sync = nativeThemeSyncQueue.then(async () => {
+        await commands.appChangeTheme(NATIVE_THEME_VALUES[normalized]);
+    });
 
-    await commands.appChangeTheme(NATIVE_THEME_VALUES[normalized]);
+    nativeThemeSyncQueue = sync.catch(() => undefined);
+    return sync;
 }
 
 export async function applyThemeMode(themeMode: unknown): Promise<void> {
+    const sequence = ++themeApplySequence;
     const normalized = resolveThemeMode(themeMode);
     const effectiveThemeMode = resolveEffectiveThemeMode(normalized);
 
     if (effectiveThemeMode === 'system') {
         await syncNativeTheme(effectiveThemeMode);
+        if (sequence !== themeApplySequence) {
+            return;
+        }
     }
 
     const resolvedTheme = getResolvedThemeMode(effectiveThemeMode);


### PR DESCRIPTION
## Summary

- restore the native window theme to system-controlled mode when the user selects `System`
- resolve the effective web theme only after releasing a previously forced native light or dark theme
- add a regression test for switching from a forced dark theme back to the system theme

## Root cause

The system preference was resolved while the native window was still forced to the previous light or dark theme. That resolved value was then sent back to the native window, so the override was never released.

## User impact

Switching from an explicit light or dark theme to `System` now immediately follows the operating system appearance and continues tracking later system theme changes.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` (326 test files, 1679 tests)
- `git diff --check upstream/master...HEAD`
