### PR TITLE
fix(profile): allow VRChat notes for current user

### DIFF
--- a/src/components/dialogs/UserDialogContent.tsx
+++ b/src/components/dialogs/UserDialogContent.tsx
@@ -325,7 +325,6 @@ export function UserDialogContent({
         applyFriendPatch,
         currentEndpoint,
         friendsById,
-        isCurrentUser,
         normalizedUserId,
         profile,
         setBaseProfile,

--- a/src/components/dialogs/user-dialog/components/UserDialogContentDialogs.tsx
+++ b/src/components/dialogs/user-dialog/components/UserDialogContentDialogs.tsx
@@ -69,7 +69,6 @@ export function UserDialogContentDialogs({
             <UserNoteMemoDialog
                 open={noteMemoDialog.open}
                 targetLabel={noteMemoDialog.targetLabel}
-                editingCurrentUser={noteMemoDialog.editingCurrentUser}
                 note={noteMemoDialog.note}
                 memo={noteMemoDialog.memo}
                 saving={noteMemoDialog.saving}

--- a/src/components/dialogs/user-dialog/components/UserNoteMemoDialog.tsx
+++ b/src/components/dialogs/user-dialog/components/UserNoteMemoDialog.tsx
@@ -20,7 +20,6 @@ import { Textarea } from '@/ui/shadcn/textarea';
 export type UserNoteMemoDialogProps = {
     open: boolean;
     targetLabel: string;
-    editingCurrentUser: boolean;
     note: string;
     memo: string;
     saving: boolean;
@@ -34,7 +33,6 @@ export type UserNoteMemoDialogProps = {
 export function UserNoteMemoDialog({
     open,
     targetLabel,
-    editingCurrentUser,
     note,
     memo,
     saving,
@@ -58,26 +56,24 @@ export function UserNoteMemoDialog({
                     ) : null}
                 </DialogHeader>
                 <FieldGroup>
-                    {!editingCurrentUser ? (
-                        <Field>
-                            <FieldLabel htmlFor="user-note-memo-note">
-                                {t('dialog.user.info.note')}
-                            </FieldLabel>
-                            <Textarea
-                                id="user-note-memo-note"
-                                value={note}
-                                maxLength={256}
-                                disabled={saving}
-                                className="min-h-24 resize-y"
-                                onChange={(event) =>
-                                    onNoteChange(event.target.value)
-                                }
-                            />
-                            <FieldDescription className="text-right text-xs">
-                                {String(note || '').length}/256
-                            </FieldDescription>
-                        </Field>
-                    ) : null}
+                    <Field>
+                        <FieldLabel htmlFor="user-note-memo-note">
+                            {t('dialog.user.info.note')}
+                        </FieldLabel>
+                        <Textarea
+                            id="user-note-memo-note"
+                            value={note}
+                            maxLength={256}
+                            disabled={saving}
+                            className="min-h-24 resize-y"
+                            onChange={(event) =>
+                                onNoteChange(event.target.value)
+                            }
+                        />
+                        <FieldDescription className="text-right text-xs">
+                            {String(note || '').length}/256
+                        </FieldDescription>
+                    </Field>
                     <Field>
                         <FieldLabel htmlFor="user-note-memo-memo">
                             {t('dialog.user.info.memo')}

--- a/src/components/dialogs/user-dialog/useUserDialogMemoState.test.tsx
+++ b/src/components/dialogs/user-dialog/useUserDialogMemoState.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    getUserMemo: vi.fn(),
+    saveUserMemo: vi.fn(),
+    saveUserNote: vi.fn(),
+    toastError: vi.fn(),
+    toastSuccess: vi.fn()
+}));
+
+vi.mock('sonner', () => ({
+    toast: {
+        error: mocks.toastError,
+        success: mocks.toastSuccess
+    }
+}));
+
+vi.mock('@/repositories/memoPersistenceRepository', () => ({
+    default: {
+        getUserMemo: mocks.getUserMemo,
+        saveUserMemo: mocks.saveUserMemo
+    }
+}));
+
+vi.mock('@/repositories/vrchatToolsRepository', () => ({
+    default: {
+        saveUserNote: mocks.saveUserNote
+    }
+}));
+
+import { useUserDialogMemoState } from './useUserDialogMemoState';
+
+type HookProps = Parameters<typeof useUserDialogMemoState>[0];
+type HookValue = ReturnType<typeof useUserDialogMemoState>;
+
+function HookHarness({
+    onValue,
+    props
+}: {
+    onValue: (value: HookValue) => void;
+    props: HookProps;
+}) {
+    onValue(useUserDialogMemoState(props));
+    return null;
+}
+
+describe('useUserDialogMemoState', () => {
+    let current: HookValue | null;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        current = null;
+        mocks.getUserMemo.mockResolvedValue({
+            userId: 'usr_self',
+            memo: 'Existing local note'
+        });
+        mocks.saveUserMemo.mockResolvedValue({
+            userId: 'usr_self',
+            memo: 'Updated local note'
+        });
+        mocks.saveUserNote.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    function value() {
+        if (!current) {
+            throw new Error('Hook value is unavailable.');
+        }
+        return current;
+    }
+
+    it('saves an updated VRChat note when editing the current user', async () => {
+        const props: HookProps = {
+            activeUserTargetRef: {
+                current: {
+                    userId: 'usr_self',
+                    endpoint: 'https://api.vrchat.cloud/api/1'
+                }
+            },
+            applyFriendPatch: vi.fn(),
+            currentEndpoint: 'https://api.vrchat.cloud/api/1',
+            friendsById: {},
+            normalizedUserId: 'usr_self',
+            profile: {
+                id: 'usr_self',
+                displayName: 'Current User',
+                note: 'Existing VRChat note'
+            },
+            setBaseProfile: vi.fn(),
+            t: ((key: string) => key) as HookProps['t']
+        };
+
+        render(
+            <HookHarness
+                onValue={(nextValue) => {
+                    current = nextValue;
+                }}
+                props={props}
+            />
+        );
+
+        await waitFor(() => {
+            expect(value().memo).toBe('Existing local note');
+        });
+
+        act(() => {
+            value().editMemo();
+        });
+        act(() => {
+            value().memoDialog.onNoteChange('Updated VRChat note');
+            value().memoDialog.onMemoChange('Updated local note');
+        });
+        await act(async () => {
+            await value().memoDialog.onSave();
+        });
+
+        expect(mocks.saveUserNote).toHaveBeenCalledWith({
+            targetUserId: 'usr_self',
+            note: 'Updated VRChat note'
+        });
+        expect(mocks.saveUserMemo).toHaveBeenCalledWith({
+            userId: 'usr_self',
+            memo: 'Updated local note'
+        });
+    });
+});

--- a/src/components/dialogs/user-dialog/useUserDialogMemoState.ts
+++ b/src/components/dialogs/user-dialog/useUserDialogMemoState.ts
@@ -23,7 +23,6 @@ function createMemoDialogState() {
         targetUserId: '',
         targetEndpoint: '',
         targetLabel: '',
-        editingCurrentUser: false,
         originalNote: '',
         note: '',
         memo: '',
@@ -40,7 +39,6 @@ type UseUserDialogMemoStateProps = {
     >['applyFriendPatch'];
     currentEndpoint: string;
     friendsById: FriendRosterById;
-    isCurrentUser: boolean;
     normalizedUserId: string;
     profile: UserDialogProfileRecord | null;
     setBaseProfile: Dispatch<SetStateAction<UserDialogProfileRecord | null>>;
@@ -52,7 +50,6 @@ export function useUserDialogMemoState({
     applyFriendPatch,
     currentEndpoint,
     friendsById,
-    isCurrentUser,
     normalizedUserId,
     profile,
     setBaseProfile,
@@ -106,7 +103,6 @@ export function useUserDialogMemoState({
             targetUserId,
             targetEndpoint: currentEndpoint,
             targetLabel: targetProfile?.displayName || targetProfile?.id || '',
-            editingCurrentUser: Boolean(isCurrentUser),
             originalNote,
             note: originalNote,
             memo
@@ -123,9 +119,7 @@ export function useUserDialogMemoState({
 
         const nextNote = String(dialog.note || '').slice(0, 256);
         const nextMemoInput = String(dialog.memo || '');
-        const nextProfileNote = dialog.editingCurrentUser
-            ? dialog.originalNote
-            : nextNote;
+        const nextProfileNote = nextNote;
 
         memoRevisionRef.current += 1;
         setMemoDialog((current: MemoDialogState) => ({
@@ -133,10 +127,7 @@ export function useUserDialogMemoState({
             saving: true
         }));
         try {
-            if (
-                !dialog.editingCurrentUser &&
-                nextNote !== dialog.originalNote
-            ) {
+            if (nextNote !== dialog.originalNote) {
                 await vrchatToolsRepository.saveUserNote({
                     targetUserId,
                     note: nextNote


### PR DESCRIPTION
## What does this PR do?

- Restores VRChat note editing for the current user now that VRChat supports self notes.
- Removes the self-specific UI and save restrictions while keeping local notes independent.
- Adds regression coverage for saving a VRChat note to the current user's ID.

## How to test

1. Open the current user's profile and choose Edit Note and Local Note.
2. Edit the VRChat note and local note, then save.
3. Reopen the dialog and confirm both values are available.

Automated checks:
- npm test -- src/components/dialogs/user-dialog/useUserDialogMemoState.test.tsx
- npm run typecheck

## Screenshots

Not included; this restores an existing field and save path for the current user.