### PR TITLE
fix: preserve global modal content during exit animations

### DIFF
--- a/src/components/hosts/ModalHost.test.tsx
+++ b/src/components/hosts/ModalHost.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import {
+    act,
+    cleanup,
+    fireEvent,
+    render,
+    screen
+} from '@testing-library/react';
 import {
     useEffect,
     useState,
@@ -206,5 +212,34 @@ describe('ModalHost', () => {
 
         expect(screen.queryByRole('alertdialog')).toBeNull();
         expect(useModalStore.getState().alertDialog.title).toBe('');
+    });
+
+    it('retains confirmation content when modal state resets during the close animation', async () => {
+        const result = useModalStore.getState().confirm({
+            title: '退出登录',
+            description: '确定要登出吗？'
+        });
+
+        render(<ModalHost />);
+
+        fireEvent.click(screen.getByRole('button', { name: '确认' }));
+        await expect(result).resolves.toMatchObject({
+            ok: true,
+            reason: 'ok'
+        });
+
+        act(() => {
+            useModalStore.getState().resetModalState();
+        });
+
+        expect(useModalStore.getState().alertDialog.title).toBe('');
+        expect(screen.getByRole('heading', { name: '退出登录' })).toBeTruthy();
+        expect(screen.getByText('确定要登出吗？')).toBeTruthy();
+
+        fireEvent.click(
+            screen.getByRole('button', { name: 'finish close animation' })
+        );
+
+        expect(screen.queryByRole('alertdialog')).toBeNull();
     });
 });

--- a/src/components/hosts/ModalHost.test.tsx
+++ b/src/components/hosts/ModalHost.test.tsx
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import type { ComponentProps, PropsWithChildren } from 'react';
+import {
+    useEffect,
+    useState,
+    type ComponentProps,
+    type PropsWithChildren
+} from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('react-i18next', () => ({
@@ -59,23 +64,46 @@ vi.mock('@/ui/shadcn/dialog', () => ({
         children,
         open,
         disablePointerDismissal = false,
-        onOpenChange
+        onOpenChange,
+        onOpenChangeComplete
     }: PropsWithChildren<{
         open: boolean;
         disablePointerDismissal?: boolean;
         onOpenChange?(open: boolean): void;
-    }>) =>
-        open ? (
+        onOpenChangeComplete?(open: boolean): void;
+    }>) => {
+        const [mounted, setMounted] = useState(open);
+
+        useEffect(() => {
+            if (open) {
+                setMounted(true);
+            }
+        }, [open]);
+
+        return mounted ? (
             <div
                 data-testid="dialog-root"
                 data-disable-pointer-dismissal={disablePointerDismissal}
+                data-state={open ? 'open' : 'closed'}
             >
                 <button type="button" onClick={() => onOpenChange?.(false)}>
                     dismiss dialog
                 </button>
+                {!open ? (
+                    <button
+                        type="button"
+                        onClick={() => {
+                            setMounted(false);
+                            onOpenChangeComplete?.(false);
+                        }}
+                    >
+                        finish close animation
+                    </button>
+                ) : null}
                 {children}
             </div>
-        ) : null,
+        ) : null;
+    },
     DialogContent: ({
         children,
         showCloseButton: _showCloseButton,
@@ -165,6 +193,18 @@ describe('ModalHost', () => {
             ok: false,
             reason: 'dismiss'
         });
+
+        expect(screen.getByRole('heading', { name: '关闭房间' })).toBeTruthy();
+        expect(screen.getByText('wrld_test:1')).toBeTruthy();
+        expect(
+            screen.getByTestId('dialog-root').getAttribute('data-state')
+        ).toBe('closed');
+
+        fireEvent.click(
+            screen.getByRole('button', { name: 'finish close animation' })
+        );
+
         expect(screen.queryByRole('alertdialog')).toBeNull();
+        expect(useModalStore.getState().alertDialog.title).toBe('');
     });
 });

--- a/src/components/hosts/ModalHost.tsx
+++ b/src/components/hosts/ModalHost.tsx
@@ -1,4 +1,5 @@
 import { REGEXP_ONLY_DIGITS, REGEXP_ONLY_DIGITS_AND_CHARS } from 'input-otp';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { BoopEmojiDialog } from '@/components/dialogs/BoopEmojiDialog';
@@ -59,6 +60,7 @@ export function ModalHost() {
     const { t } = useTranslation();
 
     const alertDialog = useModalStore((state) => state.alertDialog);
+    const [retainedAlertDialog, setRetainedAlertDialog] = useState(alertDialog);
     const promptDialog = useModalStore((state) => state.promptDialog);
     const boopDialog = useModalStore((state) => state.boopDialog);
     const otpDialog = useModalStore((state) => state.otpDialog);
@@ -94,6 +96,9 @@ export function ModalHost() {
     const closeImagePreview = useModalStore((state) => state.closeImagePreview);
     const updatePromptValue = useModalStore((state) => state.updatePromptValue);
     const updateOtpValue = useModalStore((state) => state.updateOtpValue);
+    const renderedAlertDialog = alertDialog.open
+        ? alertDialog
+        : retainedAlertDialog;
     const promptValueIsValid = matchesPromptPattern(
         promptDialog.inputPattern,
         promptDialog.value
@@ -101,11 +106,17 @@ export function ModalHost() {
     const otpValue = getOtpInputValue(otpDialog.value, otpDialog.mode);
     const otpIsRecoveryCode = otpDialog.mode === 'otp';
 
+    useEffect(() => {
+        if (alertDialog.open) {
+            setRetainedAlertDialog(alertDialog);
+        }
+    }, [alertDialog]);
+
     return (
         <>
             <Dialog
                 open={alertDialog.open}
-                disablePointerDismissal={!alertDialog.dismissible}
+                disablePointerDismissal={!renderedAlertDialog.dismissible}
                 onOpenChange={(open) => {
                     if (!open) {
                         handleDismiss();
@@ -114,51 +125,56 @@ export function ModalHost() {
                 onOpenChangeComplete={(open) => {
                     if (!open) {
                         handleAlertCloseComplete();
+                        const currentAlertDialog =
+                            useModalStore.getState().alertDialog;
+                        if (!currentAlertDialog.open) {
+                            setRetainedAlertDialog(currentAlertDialog);
+                        }
                     }
                 }}
             >
                 <DialogContent
                     role="alertdialog"
-                    showCloseButton={alertDialog.dismissible}
+                    showCloseButton={renderedAlertDialog.dismissible}
                 >
                     <DialogHeader>
-                        <DialogTitle>{alertDialog.title}</DialogTitle>
+                        <DialogTitle>{renderedAlertDialog.title}</DialogTitle>
                         <DialogDescription>
-                            {alertDialog.description}
+                            {renderedAlertDialog.description}
                         </DialogDescription>
                     </DialogHeader>
                     <DialogFooter>
-                        {alertDialog.mode === 'confirm' ? (
+                        {renderedAlertDialog.mode === 'confirm' ? (
                             <Button
                                 type="button"
                                 variant="outline"
                                 onClick={handleCancel}
                             >
-                                {alertDialog.cancelText ||
+                                {renderedAlertDialog.cancelText ||
                                     t('dialog.alertdialog.cancel')}
                             </Button>
                         ) : null}
-                        {alertDialog.alternativeText ? (
+                        {renderedAlertDialog.alternativeText ? (
                             <Button
                                 type="button"
                                 variant="outline"
                                 onClick={handleAlternative}
                             >
-                                {alertDialog.alternativeText}
+                                {renderedAlertDialog.alternativeText}
                             </Button>
                         ) : null}
                         <Button
                             type="button"
                             variant={
-                                alertDialog.destructive
+                                renderedAlertDialog.destructive
                                     ? 'destructive'
                                     : 'default'
                             }
                             onClick={handleOk}
                         >
-                            {alertDialog.confirmText ||
+                            {renderedAlertDialog.confirmText ||
                                 t(
-                                    alertDialog.mode === 'alert'
+                                    renderedAlertDialog.mode === 'alert'
                                         ? 'dialog.alertdialog.ok'
                                         : 'dialog.alertdialog.confirm'
                                 )}

--- a/src/components/hosts/ModalHost.tsx
+++ b/src/components/hosts/ModalHost.tsx
@@ -76,6 +76,9 @@ export function ModalHost() {
     const handleAlternative = useModalStore((state) => state.handleAlternative);
     const handleCancel = useModalStore((state) => state.handleCancel);
     const handleDismiss = useModalStore((state) => state.handleDismiss);
+    const handleAlertCloseComplete = useModalStore(
+        (state) => state.handleAlertCloseComplete
+    );
     const handlePromptOk = useModalStore((state) => state.handlePromptOk);
     const handlePromptCancel = useModalStore(
         (state) => state.handlePromptCancel
@@ -106,6 +109,11 @@ export function ModalHost() {
                 onOpenChange={(open) => {
                     if (!open) {
                         handleDismiss();
+                    }
+                }}
+                onOpenChangeComplete={(open) => {
+                    if (!open) {
+                        handleAlertCloseComplete();
                     }
                 }}
             >

--- a/src/state/modalStore.test.ts
+++ b/src/state/modalStore.test.ts
@@ -20,6 +20,24 @@ describe('modalStore', () => {
             destructive: true
         });
         useModalStore.getState().handleCancel();
+        expect(useModalStore.getState().alertDialog).toMatchObject({
+            open: false,
+            mode: 'alert',
+            title: 'Notice',
+            destructive: true
+        });
+        useModalStore.getState().handleAlertCloseComplete();
+        expect(useModalStore.getState().alertDialog).toEqual({
+            open: false,
+            mode: 'alert',
+            title: '',
+            description: '',
+            confirmText: '',
+            alternativeText: '',
+            cancelText: '',
+            dismissible: true,
+            destructive: false
+        });
         await expect(alertResult).resolves.toEqual({
             ok: true,
             reason: 'ok',
@@ -48,6 +66,24 @@ describe('modalStore', () => {
 
         useModalStore.getState().handleOk();
         await expect(second).resolves.toMatchObject({ ok: true, reason: 'ok' });
+    });
+
+    it('does not clear a new alert when an earlier close animation completes', async () => {
+        const first = useModalStore.getState().confirm({ title: 'First' });
+        useModalStore.getState().handleCancel();
+        await first;
+
+        const second = useModalStore.getState().alert({ title: 'Second' });
+        useModalStore.getState().handleAlertCloseComplete();
+
+        expect(useModalStore.getState().alertDialog).toMatchObject({
+            open: true,
+            mode: 'alert',
+            title: 'Second'
+        });
+
+        useModalStore.getState().handleOk();
+        await second;
     });
 
     it('resolves an optional alternative confirm action', async () => {

--- a/src/state/modalStore.ts
+++ b/src/state/modalStore.ts
@@ -83,6 +83,7 @@ type ModalStore = {
     handleAlternative(): void;
     handleCancel(): void;
     handleDismiss(): void;
+    handleAlertCloseComplete(): void;
     handlePromptOk(value?: string): void;
     handlePromptCancel(value?: string): void;
     handlePromptDismiss(value?: string): void;
@@ -207,6 +208,15 @@ export const useModalStore = create<ModalStore>((set, get) => {
         if (typeof resolver === 'function') {
             resolver(result);
         }
+    }
+
+    function hideAlertDialog() {
+        set((state) => ({
+            alertDialog: {
+                ...state.alertDialog,
+                open: false
+            }
+        }));
     }
 
     function openBaseAlert(mode: AlertMode, options: AlertDialogOptions = {}) {
@@ -363,7 +373,7 @@ export const useModalStore = create<ModalStore>((set, get) => {
                 return;
             }
 
-            set({ alertDialog: createAlertDialogState() });
+            hideAlertDialog();
             resolveAlert(createResult(true, 'ok'));
         },
         handleAlternative() {
@@ -371,7 +381,7 @@ export const useModalStore = create<ModalStore>((set, get) => {
                 return;
             }
 
-            set({ alertDialog: createAlertDialogState() });
+            hideAlertDialog();
             resolveAlert(createResult(true, 'alternative'));
         },
         handleCancel() {
@@ -380,7 +390,7 @@ export const useModalStore = create<ModalStore>((set, get) => {
                 return;
             }
 
-            set({ alertDialog: createAlertDialogState() });
+            hideAlertDialog();
             if (alertDialog.mode === 'alert') {
                 resolveAlert(createResult(true, 'ok'));
                 return;
@@ -394,13 +404,20 @@ export const useModalStore = create<ModalStore>((set, get) => {
                 return;
             }
 
-            set({ alertDialog: createAlertDialogState() });
+            hideAlertDialog();
             if (alertDialog.mode === 'alert') {
                 resolveAlert(createResult(true, 'ok'));
                 return;
             }
 
             resolveAlert(createResult(false, 'dismiss'));
+        },
+        handleAlertCloseComplete() {
+            if (get().alertDialog.open) {
+                return;
+            }
+
+            set({ alertDialog: createAlertDialogState() });
         },
         handlePromptOk(value = '') {
             const { promptDialog } = get();


### PR DESCRIPTION
## Summary

- keep global `confirm` and `alert` content intact while Base UI runs its exit animation
- clear modal content from the store only after `onOpenChangeComplete(false)`
- retain the last rendered alert snapshot when callers immediately run `resetModalState()`
- avoid clearing a newly opened alert when an earlier close animation completes

## Verification scenarios

### Normal close: friend profile "Request to Join"

1. Open a friend profile and trigger the "Request to Join" confirmation.
2. Close it with Cancel, the close button, or an outside dismissal.
3. Before this fix, the title and description were reset immediately, so the roughly 100 ms exit animation briefly showed an empty dialog with only the default button.
4. After this fix, the original title, description, and configured actions remain visible until the dialog finishes fading out.

### Immediate store reset: logout confirmation

1. While logged in, open `VRCX-0` > `Logout`.
2. Cancel once to verify the normal close path.
3. Open the logout confirmation again and confirm it.
4. Before this fix, the resolved confirmation immediately led to `resetModalState()`, recreating the empty-dialog flash during the exit animation.
5. After this fix, `ModalHost` retains the rendered logout confirmation until Base UI reports that the close animation has completed, even though the store has already reset.

Recording the window and checking the close frame-by-frame makes the before/after difference easy to see. Temporarily changing `duration-100` to `duration-1000` also makes the old behavior obvious.

## Tests

- `npm test` — 1884 tests passed
- `npm run typecheck`
- `npm run lint`
- `oxfmt --check` on the changed files