### PR TITLE
Focus VRChat after opening an instance

### DIFF
--- a/crates/host-desktop/src/game_window.rs
+++ b/crates/host-desktop/src/game_window.rs
@@ -1,0 +1,79 @@
+#[cfg(target_os = "windows")]
+pub fn focus_vrchat_window() -> bool {
+    use std::collections::HashSet;
+
+    use windows_sys::core::BOOL;
+    use windows_sys::Win32::Foundation::{HWND, LPARAM};
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        EnumWindows, FlashWindowEx, GetWindow, GetWindowThreadProcessId, IsIconic, IsWindowVisible,
+        SetForegroundWindow, ShowWindow, FLASHWINFO, FLASHW_TRAY, GW_OWNER, SW_RESTORE,
+    };
+
+    struct WindowSearch {
+        process_ids: HashSet<u32>,
+        window: HWND,
+    }
+
+    unsafe extern "system" fn find_window(window: HWND, parameter: LPARAM) -> BOOL {
+        let search = unsafe { &mut *(parameter as *mut WindowSearch) };
+        if unsafe { IsWindowVisible(window) } == 0
+            || !unsafe { GetWindow(window, GW_OWNER) }.is_null()
+        {
+            return 1;
+        }
+
+        let mut process_id = 0;
+        unsafe { GetWindowThreadProcessId(window, &mut process_id) };
+        if !search.process_ids.contains(&process_id) {
+            return 1;
+        }
+
+        search.window = window;
+        0
+    }
+
+    let process_ids = crate::process_status::vrchat_process_ids()
+        .into_iter()
+        .collect();
+    let mut search = WindowSearch {
+        process_ids,
+        window: std::ptr::null_mut(),
+    };
+    if search.process_ids.is_empty() {
+        return false;
+    }
+
+    unsafe {
+        EnumWindows(
+            Some(find_window),
+            &mut search as *mut WindowSearch as LPARAM,
+        );
+    }
+    if search.window.is_null() {
+        return false;
+    }
+
+    unsafe {
+        if IsIconic(search.window) != 0 {
+            ShowWindow(search.window, SW_RESTORE);
+        }
+        if SetForegroundWindow(search.window) != 0 {
+            return true;
+        }
+
+        let flash = FLASHWINFO {
+            cbSize: std::mem::size_of::<FLASHWINFO>() as u32,
+            hwnd: search.window,
+            dwFlags: FLASHW_TRAY,
+            uCount: 3,
+            dwTimeout: 0,
+        };
+        FlashWindowEx(&flash);
+    }
+    false
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn focus_vrchat_window() -> bool {
+    false
+}

--- a/crates/host-desktop/src/game_window.rs
+++ b/crates/host-desktop/src/game_window.rs
@@ -1,5 +1,24 @@
 #[cfg(target_os = "windows")]
 pub fn focus_vrchat_window() -> bool {
+    focus_vrchat_windows(
+        crate::process_status::vrchat_process_ids()
+            .into_iter()
+            .collect(),
+    )
+}
+
+#[cfg(target_os = "windows")]
+pub fn focus_vrchat_window_for_process(process_id: u32) -> bool {
+    use std::collections::HashSet;
+
+    if !crate::process_status::vrchat_process_ids().contains(&process_id) {
+        return false;
+    }
+    focus_vrchat_windows(HashSet::from([process_id]))
+}
+
+#[cfg(target_os = "windows")]
+fn focus_vrchat_windows(process_ids: std::collections::HashSet<u32>) -> bool {
     use std::collections::HashSet;
 
     use windows_sys::core::BOOL;
@@ -32,9 +51,6 @@ pub fn focus_vrchat_window() -> bool {
         0
     }
 
-    let process_ids = crate::process_status::vrchat_process_ids()
-        .into_iter()
-        .collect();
     let mut search = WindowSearch {
         process_ids,
         window: std::ptr::null_mut(),
@@ -75,5 +91,10 @@ pub fn focus_vrchat_window() -> bool {
 
 #[cfg(not(target_os = "windows"))]
 pub fn focus_vrchat_window() -> bool {
+    false
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn focus_vrchat_window_for_process(_process_id: u32) -> bool {
     false
 }

--- a/crates/host-desktop/src/lib.rs
+++ b/crates/host-desktop/src/lib.rs
@@ -4,6 +4,7 @@ pub mod calendar;
 pub mod clipboard;
 pub mod discord_rpc;
 pub mod game_launch;
+pub mod game_window;
 pub mod host_capabilities;
 #[cfg(target_os = "linux")]
 pub mod linux_registry;

--- a/crates/host-desktop/src/process_status.rs
+++ b/crates/host-desktop/src/process_status.rs
@@ -44,6 +44,16 @@ pub fn detect_steamvr_running() -> bool {
     detect_process_status().is_steamvr_running
 }
 
+pub fn vrchat_process_ids() -> Vec<u32> {
+    let mut sys = System::new();
+    sys.refresh_processes(ProcessesToUpdate::All, true);
+    sys.processes()
+        .values()
+        .filter(|process| is_vrchat_process_name(&process.name().to_string_lossy()))
+        .map(|process| process.pid().as_u32())
+        .collect()
+}
+
 pub fn detect_legacy_vrcx_running() -> bool {
     let mut sys = System::new();
     sys.refresh_processes(ProcessesToUpdate::All, true);

--- a/crates/host-desktop/src/vrchat_ipc.rs
+++ b/crates/host-desktop/src/vrchat_ipc.rs
@@ -1,26 +1,57 @@
-#[cfg(target_os = "windows")]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct VrcIpcSendResult {
+    pub accepted: bool,
+    pub server_process_id: Option<u32>,
+}
+
 pub fn vrcipc_send(message: &str) -> bool {
+    vrcipc_send_with_result(message).accepted
+}
+
+#[cfg(target_os = "windows")]
+pub fn vrcipc_send_with_result(message: &str) -> VrcIpcSendResult {
     use std::io::{Read, Write};
+    use std::os::windows::io::AsRawHandle;
     use std::time::Duration;
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::System::Pipes::GetNamedPipeServerProcessId;
 
     let pipe_path = r"\\.\pipe\VRChatURLLaunchPipe";
 
     let mut pipe = match open_pipe_client(pipe_path, Duration::from_secs(1)) {
         Some(p) => p,
-        None => return false,
+        None => return VrcIpcSendResult::default(),
+    };
+    let mut server_process_id = 0;
+    let server_process_id = if unsafe {
+        GetNamedPipeServerProcessId(pipe.as_raw_handle() as HANDLE, &mut server_process_id)
+    } != 0
+    {
+        Some(server_process_id)
+    } else {
+        None
     };
 
     let bytes = message.as_bytes();
     if pipe.write_all(bytes).is_err() {
-        return false;
+        return VrcIpcSendResult {
+            accepted: false,
+            server_process_id,
+        };
     }
 
     let mut result = [0u8; 1];
     if pipe.read_exact(&mut result).is_err() {
-        return false;
+        return VrcIpcSendResult {
+            accepted: false,
+            server_process_id,
+        };
     }
 
-    result[0] == 1
+    VrcIpcSendResult {
+        accepted: result[0] == 1,
+        server_process_id,
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -62,13 +93,17 @@ fn open_pipe_client(pipe_path: &str, timeout: std::time::Duration) -> Option<std
 }
 
 #[cfg(target_os = "linux")]
-pub fn vrcipc_send(message: &str) -> bool {
-    match linux_vrcipc_send(message) {
+pub fn vrcipc_send_with_result(message: &str) -> VrcIpcSendResult {
+    let accepted = match linux_vrcipc_send(message) {
         Ok(result) => result,
         Err(error) => {
             tracing::warn!(%error, "Linux VRChat launch pipe bridge failed");
             false
         }
+    };
+    VrcIpcSendResult {
+        accepted,
+        server_process_id: None,
     }
 }
 
@@ -198,8 +233,8 @@ fn linux_launch_pipe_script(payload_path: &str) -> String {
 }
 
 #[cfg(not(any(target_os = "windows", target_os = "linux")))]
-pub fn vrcipc_send(_message: &str) -> bool {
-    false
+pub fn vrcipc_send_with_result(_message: &str) -> VrcIpcSendResult {
+    VrcIpcSendResult::default()
 }
 
 #[cfg(test)]

--- a/src-tauri/src/adapters/ipc.rs
+++ b/src-tauri/src/adapters/ipc.rs
@@ -1,1 +1,1 @@
-pub use vrcx_0_host_desktop::vrchat_ipc::vrcipc_send;
+pub use vrcx_0_host_desktop::vrchat_ipc::{vrcipc_send, vrcipc_send_with_result};

--- a/src-tauri/src/commands/vrchat/instances/service.rs
+++ b/src-tauri/src/commands/vrchat/instances/service.rs
@@ -119,7 +119,11 @@ impl InstanceLaunchPipe for TauriInstanceLaunchPipe {
     ) -> vrcx_0_application_core::Result<bool> {
         require_host_capability(HostCapability::VrchatLaunchPipe)
             .map_err(|error| vrcx_0_application_core::Error::Custom(error.to_string()))?;
-        Ok(crate::adapters::ipc::vrcipc_send(launch_url))
+        let accepted = crate::adapters::ipc::vrcipc_send(launch_url);
+        if accepted {
+            vrcx_0_host_desktop::game_window::focus_vrchat_window();
+        }
+        Ok(accepted)
     }
 }
 

--- a/src-tauri/src/commands/vrchat/instances/service.rs
+++ b/src-tauri/src/commands/vrchat/instances/service.rs
@@ -119,11 +119,15 @@ impl InstanceLaunchPipe for TauriInstanceLaunchPipe {
     ) -> vrcx_0_application_core::Result<bool> {
         require_host_capability(HostCapability::VrchatLaunchPipe)
             .map_err(|error| vrcx_0_application_core::Error::Custom(error.to_string()))?;
-        let accepted = crate::adapters::ipc::vrcipc_send(launch_url);
-        if accepted {
-            vrcx_0_host_desktop::game_window::focus_vrchat_window();
+        let result = crate::adapters::ipc::vrcipc_send_with_result(launch_url);
+        if result.accepted {
+            if let Some(process_id) = result.server_process_id {
+                vrcx_0_host_desktop::game_window::focus_vrchat_window_for_process(process_id);
+            } else {
+                vrcx_0_host_desktop::game_window::focus_vrchat_window();
+            }
         }
-        Ok(accepted)
+        Ok(result.accepted)
     }
 }
 


### PR DESCRIPTION
## Summary

- focus the VRChat window after a successful in-game instance launch request
- restore minimized windows and flash the matching taskbar button when Windows denies foreground activation
- identify the named-pipe server process so multi-client setups focus the same VRChat instance that receives the launch URL

## Testing

- `cargo test -p vrcx-0-host-desktop --lib --no-default-features` (102 passed)
- `cargo check -p vrcx-0-host-desktop`
- `cargo check -p vrcx-0`