### PR TITLE
 fix(about): align GPL license button hover style with third-party notices

### DIFF
--- a/src/components/about/AboutDialog.tsx
+++ b/src/components/about/AboutDialog.tsx
@@ -287,9 +287,9 @@ export function AboutVrcxDialog({
                 <div className="mt-6 flex flex-wrap items-center justify-between gap-2 border-t pt-4">
                     <Button
                         type="button"
-                        variant="link"
+                        variant="ghost"
                         size="sm"
-                        className="text-muted-foreground/70 hover:text-foreground h-auto p-0 text-[11.5px] font-normal"
+                        className="text-muted-foreground/70 hover:text-foreground h-7 px-2 text-[11.5px] font-medium"
                         onClick={() => {
                             openExternalLink(links.license);
                         }}


### PR DESCRIPTION
## What does this PR do?
 fix align GPL license button hover style with third-party notices

## How to test
Go to about page.

## Screenshots
<img width="246" height="84" alt="image" src="https://github.com/user-attachments/assets/14bdbd71-b470-4985-98a5-732b3b076b64" />
