### PR TITLE
fix(my-avatars): prevent action menu crash

### DIFF
--- a/src/features/my-avatars/components/MyAvatarGridCard.tsx
+++ b/src/features/my-avatars/components/MyAvatarGridCard.tsx
@@ -104,11 +104,13 @@ export function AvatarActionMenuItems({
 
     return (
         <>
-            <Label className="max-w-64 truncate">
-                {avatar?.name ||
-                    avatar?.id ||
-                    t('view.my_avatars.label.untitled_avatar')}
-            </Label>
+            <Group>
+                <Label className="max-w-64 truncate">
+                    {avatar?.name ||
+                        avatar?.id ||
+                        t('view.my_avatars.label.untitled_avatar')}
+                </Label>
+            </Group>
             <Separator />
             <Group>
                 <Item {...actionItemProps('details')}>

--- a/src/features/my-avatars/components/MyAvatarsViewParts.test.tsx
+++ b/src/features/my-avatars/components/MyAvatarsViewParts.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('react-i18next', () => ({
@@ -11,8 +11,9 @@ vi.mock('@/services/dialogService', () => ({
     openAvatarDialog: vi.fn()
 }));
 
+import { getMyAvatarsGridDensityConfig } from '../myAvatarsGrid';
 import type { MyAvatarActionHandler, MyAvatarRow } from '../myAvatarsTypes';
-import { AvatarActionMenuItems } from './MyAvatarGridCard';
+import { AvatarActionMenuItems, MyAvatarGridCard } from './MyAvatarGridCard';
 import { PlatformBadges } from './MyAvatarsViewParts';
 
 describe('My Avatars view parts', () => {
@@ -58,5 +59,32 @@ describe('My Avatars view parts', () => {
         fireEvent.click(screen.getByText('dialog.avatar.actions.make_public'));
 
         expect(onAction).toHaveBeenCalledWith('makePublic', avatar);
+    });
+
+    it('opens the grid card action menu', () => {
+        render(
+            <MyAvatarGridCard
+                avatar={{
+                    id: 'avtr_example',
+                    name: 'Example Avatar',
+                    releaseStatus: 'private'
+                }}
+                densityConfig={getMyAvatarsGridDensityConfig('standard')}
+                isUpdating={false}
+                onAction={vi.fn<MyAvatarActionHandler>()}
+            />
+        );
+
+        fireEvent.click(
+            screen.getByRole('button', {
+                name: 'view.my_avatars.action.open_avatar_actions'
+            })
+        );
+
+        const menu = screen.getByRole('menu');
+        expect(menu).toBeTruthy();
+        expect(
+            within(menu).getByText('common.actions.view_details')
+        ).toBeTruthy();
     });
 });


### PR DESCRIPTION
## Summary
- place the avatar name label inside a Base UI menu group
- prevent the My Avatars action menu from crashing the route when opened
- add an interaction regression test that opens the real grid-card dropdown

## Root cause
The avatar label added in v2.24 was rendered outside Menu.Group. Base UI only creates MenuGroupContext for labels nested in a group, so opening the lazily rendered menu threw and activated the route error boundary.

## Tests
- npm.cmd test -- src/features/my-avatars/components/MyAvatarsViewParts.test.tsx
- npx.cmd oxlint src/features/my-avatars/components/MyAvatarGridCard.tsx src/features/my-avatars/components/MyAvatarsViewParts.test.tsx --deny-warnings
- npx.cmd oxfmt --check src/features/my-avatars/components/MyAvatarGridCard.tsx src/features/my-avatars/components/MyAvatarsViewParts.test.tsx