### PR TITLE
perf(cache): batch avatar and world cache writes

### DIFF
--- a/crates/application-core/src/world_cache/runtime.rs
+++ b/crates/application-core/src/world_cache/runtime.rs
@@ -10,7 +10,7 @@ use vrcx_0_core::ReleaseStatus;
 use vrcx_0_persistence::cache_entities::CacheEntityInput;
 use vrcx_0_persistence::worlds::{
     world_cache_get, world_cache_get_many, world_cache_search, world_cache_upsert,
-    WorldSummaryOutput,
+    world_cache_upsert_many, WorldSummaryOutput,
 };
 use vrcx_0_persistence::DatabaseService;
 use vrcx_0_vrchat_client::http_api::{
@@ -153,14 +153,21 @@ impl WorldCache {
     }
 
     pub fn hydrate_summary_from_payload(&self, world_value: &Value) -> Option<WorldSummaryOutput> {
-        self.hydrate_summary_from_payload_with_policy(world_value, false)
+        let (summary, entry) = self.hydrate_summary_from_payload_with_policy(world_value, false)?;
+        if let Some(entry) = entry {
+            let world_id = summary.id.clone();
+            if let Err(error) = world_cache_upsert(self.db.as_ref(), entry) {
+                tracing::warn!(world_id = %world_id, "WorldCache upsert failed: {error}");
+            }
+        }
+        Some(summary)
     }
 
     fn hydrate_summary_from_payload_with_policy(
         &self,
         world_value: &Value,
         insert_private: bool,
-    ) -> Option<WorldSummaryOutput> {
+    ) -> Option<(WorldSummaryOutput, Option<CacheEntityInput>)> {
         let world_id = world_id(world_value);
         if world_id.is_empty() {
             return None;
@@ -177,25 +184,23 @@ impl WorldCache {
 
         let persist = is_persistable_world(world_value, &name)
             || (insert_private && is_cacheable_private_world(world_value, &name));
-        if persist {
-            let entry = CacheEntityInput {
-                id: Value::String(world_id.clone()),
-                author_id: value_or_null(world_value, "authorId"),
-                author_name: value_or_null(world_value, "authorName"),
-                created_at: value_or_null_with_fallback(world_value, "created_at", "createdAt"),
-                description: value_or_null(world_value, "description"),
-                image_url: value_or_null(world_value, "imageUrl"),
-                name: Value::String(name.clone()),
-                release_status: value_or_null(world_value, "releaseStatus"),
-                thumbnail_image_url: value_or_null(world_value, "thumbnailImageUrl"),
-                updated_at: value_or_null_with_fallback(world_value, "updated_at", "updatedAt"),
-                version: value_or_null(world_value, "version"),
-            };
-            if let Err(error) = world_cache_upsert(self.db.as_ref(), entry) {
-                tracing::warn!(world_id = %world_id, "WorldCache upsert failed: {error}");
-            }
+        if !persist {
+            return Some((summary, None));
         }
-        Some(summary)
+        let entry = CacheEntityInput {
+            id: Value::String(world_id.clone()),
+            author_id: value_or_null(world_value, "authorId"),
+            author_name: value_or_null(world_value, "authorName"),
+            created_at: value_or_null_with_fallback(world_value, "created_at", "createdAt"),
+            description: value_or_null(world_value, "description"),
+            image_url: value_or_null(world_value, "imageUrl"),
+            name: Value::String(name.clone()),
+            release_status: value_or_null(world_value, "releaseStatus"),
+            thumbnail_image_url: value_or_null(world_value, "thumbnailImageUrl"),
+            updated_at: value_or_null_with_fallback(world_value, "updated_at", "updatedAt"),
+            version: value_or_null(world_value, "version"),
+        };
+        Some((summary, Some(entry)))
     }
 
     pub fn hydrate_favorite_payloads<'a>(
@@ -232,17 +237,23 @@ impl WorldCache {
                 }
             }
         };
-        world_values
+        let mut pending = Vec::new();
+        let payloads = world_values
             .into_iter()
             .map(|world_value| {
                 let id = world_id(world_value);
-                let summary = self.hydrate_summary_from_payload_with_policy(
+                let (summary, entry) = self.hydrate_summary_from_payload_with_policy(
                     world_value,
                     private_ids_to_insert.contains(&id),
                 )?;
+                pending.extend(entry);
                 self.get_cached_card_payload(&summary.id)
             })
-            .collect()
+            .collect();
+        if let Err(error) = world_cache_upsert_many(self.db.as_ref(), pending) {
+            tracing::warn!("WorldCache batch upsert failed: {error}");
+        }
+        payloads
     }
 
     pub async fn resolve_name(

--- a/crates/application/src/favorites/favorite_details_hydrate.rs
+++ b/crates/application/src/favorites/favorite_details_hydrate.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use tokio::sync::Mutex as AsyncMutex;
 use vrcx_0_core::json::RawJson;
 use vrcx_0_persistence::{
-    avatars::{avatar_cache_existing_ids, avatar_cache_upsert},
+    avatars::{avatar_cache_existing_ids, avatar_cache_upsert_many},
     DatabaseService,
 };
 use vrcx_0_vrchat_client::{
@@ -546,43 +546,53 @@ fn hydrate_world_details(
 }
 
 fn persist_avatar_details(db: &DatabaseService, details_by_id: &HashMap<String, Value>) -> u32 {
-    let insert_candidates = details_by_id
+    let writable = details_by_id
         .iter()
-        .filter(|(_, entity)| {
-            cache_write_decision(FavoriteCacheKind::Avatar, entity)
-                == CacheWriteDecision::InsertIfMissing
+        .map(|(id, entity)| {
+            (
+                id,
+                entity,
+                cache_write_decision(FavoriteCacheKind::Avatar, entity),
+            )
         })
-        .map(|(id, _)| id.clone())
+        .filter(|(_, _, decision)| *decision != CacheWriteDecision::Skip)
         .collect::<Vec<_>>();
-    let existing_ids: HashSet<String> = if insert_candidates.is_empty() {
-        HashSet::new()
+
+    let insert_candidates = writable
+        .iter()
+        .filter(|(_, _, decision)| *decision == CacheWriteDecision::InsertIfMissing)
+        .map(|(id, _, _)| (*id).clone())
+        .collect::<Vec<_>>();
+    let existing_ids: Option<HashSet<String>> = if insert_candidates.is_empty() {
+        Some(HashSet::new())
     } else {
         match avatar_cache_existing_ids(db, &insert_candidates) {
-            Ok(ids) => ids.into_iter().collect(),
+            Ok(ids) => Some(ids.into_iter().collect()),
             Err(error) => {
                 tracing::warn!("failed to read favorite avatar cache: {error}");
-                return 0;
+                None
             }
         }
     };
 
-    let mut cached_count = 0;
-    for (id, entity) in details_by_id {
-        let decision = cache_write_decision(FavoriteCacheKind::Avatar, entity);
-        if decision == CacheWriteDecision::Skip {
-            continue;
-        }
-        if decision == CacheWriteDecision::InsertIfMissing && existing_ids.contains(id) {
-            continue;
-        }
-        match avatar_cache_upsert(db, cache_entry_from_entity(entity, id)) {
-            Ok(_) => cached_count += 1,
-            Err(error) => {
-                tracing::warn!("failed to cache favorite avatar details for {id}: {error}");
-            }
+    let entries = writable
+        .into_iter()
+        .filter(|(id, _, decision)| match decision {
+            CacheWriteDecision::InsertIfMissing => existing_ids
+                .as_ref()
+                .is_some_and(|existing| !existing.contains(*id)),
+            _ => true,
+        })
+        .map(|(id, entity, _)| cache_entry_from_entity(entity, id))
+        .collect::<Vec<_>>();
+
+    match avatar_cache_upsert_many(db, entries) {
+        Ok(cached_count) => cached_count,
+        Err(error) => {
+            tracing::warn!("failed to cache favorite avatar details: {error}");
+            0
         }
     }
-    cached_count
 }
 
 fn ensure_scope_matches(

--- a/crates/persistence/src/avatars.rs
+++ b/crates/persistence/src/avatars.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use vrcx_0_core::ReleaseStatus;
 
-use crate::cache_entities::{upsert_cache_entity, CacheEntityInput};
+use crate::cache_entities::{upsert_cache_entities, upsert_cache_entity, CacheEntityInput};
 use crate::common::{normalize_text, now_iso, row_i64, row_string, ParamsBuilder};
 use crate::database::schema::{ensure_global_store_tables, ensure_user_store_tables};
 use crate::database::DatabaseService;
@@ -66,6 +66,13 @@ pub struct AvatarTagsPatchInput {
 
 pub fn avatar_cache_upsert(db: &DatabaseService, entry: CacheEntityInput) -> Result<i64, Error> {
     upsert_cache_entity(db, "cache_avatar", entry)
+}
+
+pub fn avatar_cache_upsert_many(
+    db: &DatabaseService,
+    entries: Vec<CacheEntityInput>,
+) -> Result<u32, Error> {
+    upsert_cache_entities(db, "cache_avatar", entries)
 }
 
 pub fn avatar_cache_get(

--- a/crates/persistence/src/avatars/tests.rs
+++ b/crates/persistence/src/avatars/tests.rs
@@ -125,3 +125,54 @@ fn avatar_cache_preserves_unknown_release_status() -> Result<(), Error> {
     );
     Ok(())
 }
+
+#[test]
+fn cache_upsert_many_writes_the_whole_batch() -> Result<(), Error> {
+    let dir = TestDir::new("avatar-upsert-many");
+    let db = DatabaseService::new(&dir.path.join("VRCX-0.sqlite3"))?;
+
+    let entries = (0..300)
+        .map(|index| avatar_entry(&format!("avtr_{index}")))
+        .collect::<Vec<_>>();
+    let written = avatar_cache_upsert_many(&db, entries)?;
+
+    assert_eq!(written, 300);
+    for index in [0, 150, 299] {
+        assert!(avatar_cache_get(&db, format!("avtr_{index}"))?.is_some());
+    }
+    Ok(())
+}
+
+#[test]
+fn cache_upsert_many_skips_malformed_entries_without_losing_the_batch() -> Result<(), Error> {
+    let dir = TestDir::new("avatar-upsert-many-invalid");
+    let db = DatabaseService::new(&dir.path.join("VRCX-0.sqlite3"))?;
+
+    let mut invalid = avatar_entry("avtr_placeholder");
+    invalid.id = json!("   ");
+    let entries = vec![avatar_entry("avtr_a"), invalid, avatar_entry("avtr_b")];
+
+    let written = avatar_cache_upsert_many(&db, entries)?;
+
+    assert_eq!(written, 2);
+    assert!(avatar_cache_get(&db, "avtr_a".into())?.is_some());
+    assert!(avatar_cache_get(&db, "avtr_b".into())?.is_some());
+    Ok(())
+}
+
+#[test]
+fn cache_upsert_many_overwrites_an_existing_snapshot() -> Result<(), Error> {
+    let dir = TestDir::new("avatar-upsert-many-overwrite");
+    let db = DatabaseService::new(&dir.path.join("VRCX-0.sqlite3"))?;
+
+    avatar_cache_upsert(&db, avatar_entry("avtr_a"))?;
+    let mut updated = avatar_entry("avtr_a");
+    updated.name = json!("Renamed Avatar");
+    avatar_cache_upsert_many(&db, vec![updated])?;
+
+    assert_eq!(
+        avatar_cache_get(&db, "avtr_a".into())?.unwrap().name,
+        "Renamed Avatar"
+    );
+    Ok(())
+}

--- a/crates/persistence/src/cache_entities.rs
+++ b/crates/persistence/src/cache_entities.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::common::{now_iso, ParamsBuilder};
+use crate::common::{insert_or_replace_sql, now_iso, DbWriteTarget, ParamsBuilder};
 use crate::database::schema::ensure_global_store_tables;
 use crate::database::DatabaseService;
 use crate::Error;
@@ -33,22 +33,91 @@ pub struct CacheEntityInput {
     pub version: Value,
 }
 
+const CACHE_ENTITY_CHUNK_SIZE: usize = 5000;
+
+const CACHE_ENTITY_COLUMNS: &[&str] = &[
+    "id",
+    "added_at",
+    "author_id",
+    "author_name",
+    "created_at",
+    "description",
+    "image_url",
+    "name",
+    "release_status",
+    "thumbnail_image_url",
+    "updated_at",
+    "version",
+];
+
 pub(crate) fn upsert_cache_entity(
     db: &DatabaseService,
     table_name: &str,
     entry: CacheEntityInput,
 ) -> Result<i64, Error> {
-    let id = entry
+    let id = cache_entity_id(&entry)?;
+    ensure_global_store_tables(db)?;
+    upsert_cache_entity_on(
+        db,
+        &insert_or_replace_sql(table_name, CACHE_ENTITY_COLUMNS),
+        id,
+        entry,
+    )
+}
+
+pub(crate) fn upsert_cache_entities(
+    db: &DatabaseService,
+    table_name: &str,
+    entries: Vec<CacheEntityInput>,
+) -> Result<u32, Error> {
+    if entries.is_empty() {
+        return Ok(0);
+    }
+    ensure_global_store_tables(db)?;
+    let sql = insert_or_replace_sql(table_name, CACHE_ENTITY_COLUMNS);
+    let mut remaining = entries;
+    let mut written = 0;
+    while !remaining.is_empty() {
+        let take = remaining.len().min(CACHE_ENTITY_CHUNK_SIZE);
+        let chunk = remaining.drain(..take).collect::<Vec<_>>();
+        written += db.write_transaction(|tx| {
+            let mut chunk_written = 0;
+            for entry in chunk {
+                let id = match cache_entity_id(&entry) {
+                    Ok(id) => id,
+                    Err(error) => {
+                        tracing::warn!("skipped malformed {table_name} entity: {error}");
+                        continue;
+                    }
+                };
+                upsert_cache_entity_on(tx, &sql, id, entry)?;
+                chunk_written += 1;
+            }
+            Ok(chunk_written)
+        })?;
+    }
+    Ok(written)
+}
+
+fn cache_entity_id(entry: &CacheEntityInput) -> Result<String, Error> {
+    entry
         .id
         .as_str()
         .map(str::trim)
         .filter(|id| !id.is_empty())
-        .ok_or_else(|| Error::InvalidData("Cache entity id must be a non-empty string.".into()))?
-        .to_owned();
-    ensure_global_store_tables(db)?;
+        .ok_or_else(|| Error::InvalidData("Cache entity id must be a non-empty string.".into()))
+        .map(ToOwned::to_owned)
+}
+
+fn upsert_cache_entity_on(
+    target: &impl DbWriteTarget,
+    sql: &str,
+    id: String,
+    entry: CacheEntityInput,
+) -> Result<i64, Error> {
     let now = now_iso();
-    db.execute_non_query(
-        &format!("INSERT OR REPLACE INTO {table_name} (id, added_at, author_id, author_name, created_at, description, image_url, name, release_status, thumbnail_image_url, updated_at, version) VALUES (@id, @added_at, @author_id, @author_name, @created_at, @description, @image_url, @name, @release_status, @thumbnail_image_url, @updated_at, @version)"),
+    target.execute_non_query(
+        sql,
         &ParamsBuilder::new()
             .set("id", id)
             .set("added_at", now)

--- a/crates/persistence/src/worlds.rs
+++ b/crates/persistence/src/worlds.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use serde_json::Value;
 use vrcx_0_core::ReleaseStatus;
 
-use crate::cache_entities::{upsert_cache_entity, CacheEntityInput};
+use crate::cache_entities::{upsert_cache_entities, upsert_cache_entity, CacheEntityInput};
 use crate::common::{normalize_text, row_i64, row_string, ParamsBuilder};
 use crate::database::schema::ensure_global_store_tables;
 use crate::database::DatabaseService;
@@ -32,6 +32,13 @@ pub struct WorldSummaryOutput {
 
 pub fn world_cache_upsert(db: &DatabaseService, entry: CacheEntityInput) -> Result<i64, Error> {
     upsert_cache_entity(db, "cache_world", entry)
+}
+
+pub fn world_cache_upsert_many(
+    db: &DatabaseService,
+    entries: Vec<CacheEntityInput>,
+) -> Result<u32, Error> {
+    upsert_cache_entities(db, "cache_world", entries)
 }
 
 pub fn world_cache_remove(db: &DatabaseService, world_id: String) -> Result<(), Error> {
@@ -290,5 +297,72 @@ mod tests {
         assert!(world_cache_search(db.as_ref(), "Invalid World", 10)
             .unwrap()
             .is_empty());
+    }
+
+    #[test]
+    fn cache_upsert_many_persists_a_typical_favourites_page_in_one_pass() {
+        let (_dir, db) = test_db("upsert-many");
+
+        let entries = (0..300)
+            .map(|index| world_entry(&format!("wrld_{index}"), &format!("World {index}")))
+            .collect::<Vec<_>>();
+        let written = world_cache_upsert_many(db.as_ref(), entries).unwrap();
+
+        assert_eq!(written, 300);
+        for index in [0, 150, 299] {
+            assert!(world_cache_get(db.as_ref(), format!("wrld_{index}"))
+                .unwrap()
+                .is_some());
+        }
+    }
+
+    #[test]
+    fn cache_upsert_many_skips_malformed_entries_without_losing_the_batch() {
+        let (_dir, db) = test_db("upsert-many-invalid");
+
+        let mut invalid = world_entry("wrld_placeholder", "Invalid World");
+        invalid.id = json!(null);
+        let entries = vec![
+            world_entry("wrld_ok_a", "World A"),
+            invalid,
+            world_entry("wrld_ok_b", "World B"),
+        ];
+
+        let written = world_cache_upsert_many(db.as_ref(), entries).unwrap();
+
+        assert_eq!(written, 2);
+        assert!(world_cache_get(db.as_ref(), "wrld_ok_a".into())
+            .unwrap()
+            .is_some());
+        assert!(world_cache_get(db.as_ref(), "wrld_ok_b".into())
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn cache_upsert_many_reports_database_failures_instead_of_swallowing_them() {
+        let (_dir, db) = test_db("upsert-many-db-error");
+        world_cache_upsert(db.as_ref(), world_entry("wrld_seed", "Seed")).unwrap();
+        db.execute_non_query("DROP TABLE cache_world", &Default::default())
+            .unwrap();
+        db.execute_non_query(
+            "CREATE TABLE cache_world (id TEXT PRIMARY KEY, added_at TEXT, author_id TEXT, author_name TEXT, created_at TEXT, description TEXT, image_url TEXT, name TEXT, release_status TEXT, thumbnail_image_url TEXT, updated_at TEXT, version INTEGER, required_extra TEXT NOT NULL)",
+            &Default::default(),
+        )
+        .unwrap();
+
+        let result = world_cache_upsert_many(db.as_ref(), vec![world_entry("wrld_a", "World A")]);
+
+        assert!(
+            result.is_err(),
+            "a schema-level write failure must surface, not be downgraded to Ok"
+        );
+    }
+
+    #[test]
+    fn cache_upsert_many_is_a_noop_for_an_empty_batch() {
+        let (_dir, db) = test_db("upsert-many-empty");
+
+        assert_eq!(world_cache_upsert_many(db.as_ref(), Vec::new()).unwrap(), 0);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Cache entity writes went through `execute_non_query` one row at a time, so each
one took the single writer connection and committed on its own. Hydrating a page
of favorites (`FAVORITE_DETAILS_PAGE_SIZE` is 300, up to 50 pages) meant that
many separate WAL commits, all competing with game-log ingestion for the writer.

- add `upsert_cache_entities`, which calls `ensure_global_store_tables` once and
  writes the batch inside a single `db.write_transaction`, chunked at 5000 like
  `repair_zero_copresence_durations` already does
- use the existing `insert_or_replace_sql` helper so the statement is built once
  per batch rather than reformatted for every row
- have `hydrate_summary_from_payload_with_policy` return the entry to persist
  instead of writing it itself, so the favorites path can collect and flush once
- validate the entity id before touching the schema, so a malformed entry still
  reports `InvalidData` rather than a database error

Malformed entries are still skipped individually, as before. Genuine database
failures now propagate instead of being logged and reported as success — the
previous per-row calls returned `Err`, and folding them into a batch would
otherwise have hidden a full disk behind `Ok(0)`.

## How to test

- `cargo test -p vrcx-0-persistence -p vrcx-0-application-core -p vrcx-0-application` — 905 tests
- `cargo clippy -p vrcx-0-persistence -p vrcx-0-application-core -p vrcx-0-application --all-targets -- -D warnings`
- `cargo fmt --check`

New tests cover a full favorites-sized page, malformed entries inside a batch,
an empty batch, overwriting an existing snapshot, and a schema-level write
failure surfacing as `Err` rather than `Ok`.

## Screenshots

No UI changes.
