### PR TITLE
fix(realtime): prevent duplicate unfriend notifications

### DIFF
--- a/crates/application-realtime/src/realtime/friends/runtime/event_patch.rs
+++ b/crates/application-realtime/src/realtime/friends/runtime/event_patch.rs
@@ -209,6 +209,7 @@ fn apply_delete(
 ) -> Option<()> {
     let user_id = event_user_id(content)?;
     let previous = get_friend_record(state, &user_id);
+    previous.as_ref()?;
     state.pending_offline.remove(&user_id);
     state.recent_gps.remove(&user_id);
     let friend_was_removed = state

--- a/crates/application-realtime/src/realtime/friends/runtime/event_patch.rs
+++ b/crates/application-realtime/src/realtime/friends/runtime/event_patch.rs
@@ -209,7 +209,6 @@ fn apply_delete(
 ) -> Option<()> {
     let user_id = event_user_id(content)?;
     let previous = get_friend_record(state, &user_id);
-    previous.as_ref()?;
     state.pending_offline.remove(&user_id);
     state.recent_gps.remove(&user_id);
     let friend_was_removed = state
@@ -225,17 +224,19 @@ fn apply_delete(
         target_user_id: user_id.clone(),
         created_at: now.iso.clone(),
     });
-    let patch = json!({ "id": user_id.clone() });
-    output
-        .persistence
-        .feed_entries
-        .push(friend_relationship_feed_entry(
-            FriendRelationshipFeedKind::Unfriend,
-            &user_id,
-            &patch,
-            previous.as_ref(),
-            &now.iso,
-        ));
+    if let Some(previous) = previous.as_ref() {
+        let patch = json!({ "id": user_id.clone() });
+        output
+            .persistence
+            .feed_entries
+            .push(friend_relationship_feed_entry(
+                FriendRelationshipFeedKind::Unfriend,
+                &user_id,
+                &patch,
+                Some(previous),
+                &now.iso,
+            ));
+    }
     output.projection.friend_log_changed = true;
     Some(())
 }

--- a/crates/application-realtime/src/realtime/friends/runtime/presence_tests.rs
+++ b/crates/application-realtime/src/realtime/friends/runtime/presence_tests.rs
@@ -717,6 +717,20 @@ mod tests {
             output.persistence.feed_entries[0]["displayName"],
             "Removed Friend"
         );
+
+        assert!(matches!(
+            runtime.apply_ws_message(&RealtimeWsMessagePayload {
+                json: json!({
+                    "type": "friend-delete",
+                    "content": {
+                        "userId": "usr_removed"
+                    }
+                }),
+                raw: "{}".into(),
+                received_at: "2026-05-15T00:00:01Z".into(),
+            }),
+            RealtimeFriendApplyResult::Ignored
+        ));
     }
 
     #[test]

--- a/crates/application-realtime/src/realtime/friends/runtime/presence_tests.rs
+++ b/crates/application-realtime/src/realtime/friends/runtime/presence_tests.rs
@@ -718,7 +718,7 @@ mod tests {
             "Removed Friend"
         );
 
-        assert!(matches!(
+        let RealtimeFriendApplyResult::Output(retry) =
             runtime.apply_ws_message(&RealtimeWsMessagePayload {
                 json: json!({
                     "type": "friend-delete",
@@ -728,9 +728,17 @@ mod tests {
                 }),
                 raw: "{}".into(),
                 received_at: "2026-05-15T00:00:01Z".into(),
-            }),
-            RealtimeFriendApplyResult::Ignored
-        ));
+            })
+        else {
+            panic!("repeated friend-delete should retry persistence");
+        };
+
+        assert_eq!(retry.persistence.friend_log_deletes.len(), 1);
+        assert_eq!(
+            retry.persistence.friend_log_deletes[0].target_user_id,
+            "usr_removed"
+        );
+        assert!(retry.persistence.feed_entries.is_empty());
     }
 
     #[test]

--- a/crates/application-realtime/src/realtime/service/host/friend_baseline_tests.rs
+++ b/crates/application-realtime/src/realtime/service/host/friend_baseline_tests.rs
@@ -1671,6 +1671,91 @@ fn friend_projection_clears_feed_entries_when_persistence_fails() -> Result<()> 
 }
 
 #[test]
+fn repeated_friend_delete_retries_after_persistence_failure_without_duplicate_feed() -> Result<()> {
+    let (_dir, runtime, active_session) =
+        runtime_with_active_session("friend-delete-persistence-retry")?;
+    runtime.runtime().sync_friend_snapshot(
+        active_session.clone(),
+        Some(7),
+        [(
+            "usr_friend".to_string(),
+            FriendRecord {
+                id: "usr_friend".into(),
+                display_name: "Friend".into(),
+                state: "offline".into(),
+                ..FriendRecord::default()
+            },
+        )]
+        .into_iter()
+        .collect(),
+    )?;
+    write_realtime_batch(
+        runtime.runtime().deps.db.as_ref(),
+        &OwnerId::new(active_session.user_id.clone()),
+        &RealtimePersistenceBatch {
+            friend_log_upserts: vec![vrcx_0_persistence::realtime::FriendLogUpsert {
+                target_user_id: "usr_friend".into(),
+                display_name: "Friend".into(),
+                trust_level: "Visitor".into(),
+                friend_number: 1,
+                created_at: "2026-05-15T00:00:00Z".into(),
+                force_history: false,
+            }],
+            ..RealtimePersistenceBatch::default()
+        },
+    )?;
+    runtime.runtime().deps.event_bus.take_events_for_test();
+    let payload = RealtimeWsMessagePayload {
+        json: json!({
+            "type": "friend-delete",
+            "content": { "userId": "usr_friend" }
+        }),
+        raw: "{}".into(),
+        received_at: "2026-05-15T00:00:01Z".into(),
+    };
+
+    let RealtimeFriendApplyResult::Output(mut first) =
+        runtime.runtime().friends.apply_ws_message(&payload)
+    else {
+        panic!("first friend-delete should produce an output");
+    };
+    first.persistence.feed_entries[0]["type"] = json!("NewFeedType");
+    runtime.runtime().apply_friend_output(*first);
+
+    assert_eq!(
+        vrcx_0_persistence::friends::friend_log_current_list(
+            runtime.runtime().deps.db.as_ref(),
+            active_session.user_id.clone(),
+        )?
+        .len(),
+        1
+    );
+
+    let RealtimeFriendApplyResult::Output(retry) =
+        runtime.runtime().friends.apply_ws_message(&payload)
+    else {
+        panic!("repeated friend-delete should retry persistence");
+    };
+    assert_eq!(retry.persistence.friend_log_deletes.len(), 1);
+    assert!(retry.persistence.feed_entries.is_empty());
+    runtime.runtime().apply_friend_output(*retry);
+
+    assert!(vrcx_0_persistence::friends::friend_log_current_list(
+        runtime.runtime().deps.db.as_ref(),
+        active_session.user_id,
+    )?
+    .is_empty());
+    assert!(runtime
+        .runtime()
+        .deps
+        .event_bus
+        .take_events_for_test()
+        .iter()
+        .all(|event| event.name != "realtimeFeedProjection"));
+    Ok(())
+}
+
+#[test]
 fn disabled_feed_persistence_keeps_projection_and_other_batch_writes() -> Result<()> {
     let (_dir, runtime, active_session) =
         runtime_with_active_session("friend-feed-persistence-disabled")?;


### PR DESCRIPTION
## Summary

- Make friend deletion handling idempotent when the friend has already been removed from the realtime roster.
- Prevent the second delete event from generating an Unknown unfriend notification.
- Add a regression test for repeated friend-delete events.

## Validation

- cargo fmt --all -- --check
- cargo clippy -p vrcx-0-application-realtime --all-targets --no-deps -- -D warnings
- cargo test -p vrcx-0-application-realtime friend_delete_generates_unfriend_feed_entry --lib
- cargo test -p vrcx-0-application unfriend_locally_applies_via_synthetic_event_when_baseline_present --lib