### PR TITLE
fix(user-dialog): show owned mutual groups in both sections

### DIFF
--- a/src/components/dialogs/user-dialog/userDialogGroupRows.ts
+++ b/src/components/dialogs/user-dialog/userDialogGroupRows.ts
@@ -351,15 +351,18 @@ export function splitUserGroups(
     const remainingGroups: UserGroupRow[] = [];
 
     for (const group of groups || []) {
-        if (isOwnedGroupForUser(group, userId)) {
+        const isOwnedGroup = isOwnedGroupForUser(group, userId);
+        const isMutual = isMutualGroupForUser(group, isCurrentUser);
+
+        if (isOwnedGroup) {
             ownGroups.push(group);
-            continue;
         }
-        if (isMutualGroupForUser(group, isCurrentUser)) {
+        if (isMutual) {
             mutualGroups.push(group);
-            continue;
         }
-        remainingGroups.push(group);
+        if (!isOwnedGroup && !isMutual) {
+            remainingGroups.push(group);
+        }
     }
 
     return { ownGroups, mutualGroups, remainingGroups };

--- a/src/components/dialogs/user-dialog/userDialogRows.test.ts
+++ b/src/components/dialogs/user-dialog/userDialogRows.test.ts
@@ -222,6 +222,27 @@ describe('userDialogRows', () => {
         ]);
     });
 
+    it('keeps an owned mutual group visible in both sections', () => {
+        const groups = normalizeUserGroupMembershipRows([
+            {
+                id: 'grp_owned_mutual',
+                name: 'Owned Mutual Group',
+                ownerId: 'usr_profile',
+                mutualGroup: true
+            }
+        ]);
+
+        const sections = splitUserGroups(groups, 'usr_profile', false);
+
+        expect(sections.ownGroups.map(groupIdForRow)).toEqual([
+            'grp_owned_mutual'
+        ]);
+        expect(sections.mutualGroups.map(groupIdForRow)).toEqual([
+            'grp_owned_mutual'
+        ]);
+        expect(sections.remainingGroups).toEqual([]);
+    });
+
     it('shows previous display names from profile history or cached stats', () => {
         expect(
             normalizePreviousDisplayNames(


### PR DESCRIPTION
## What does this PR do?

Fixes the user profile Groups tab so a group owned by the viewed user can also appear in Mutual Groups when the current user is a member.

The owned and mutual classifications are independent, while Groups continues to contain only entries that match neither classification. A regression test covers the overlapping owned-and-mutual case.

## How to test

1. Open another user's profile where they own a group that the current user has also joined.
2. Open the Groups tab.
3. Verify that the group appears in both Own Groups and Mutual Groups.

Automated verification:

- Targeted test: 12 tests passed.
- Full test suite: 485 test files and 2,497 tests passed.
- Formatting and lint checks passed for the changed files.

## Screenshots

Not applicable; there are no visual changes.