### PR TITLE
feat(avatar): show platform performance limits and localized ranks

### DIFF
--- a/src/components/dialogs/avatar-dialog/components/AvatarDialogHeaderBadges.tsx
+++ b/src/components/dialogs/avatar-dialog/components/AvatarDialogHeaderBadges.tsx
@@ -27,12 +27,17 @@ function PlatformBadge({
     fileSize?: string;
     icon?: LucideIcon;
 }) {
+    const { t } = useTranslation();
     return (
         <Badge variant="outline">
             {Icon ? <Icon data-icon="inline-start" /> : null}
             {label}
             {rating ? (
-                <span className="ml-1 border-l pl-1">{rating}</span>
+                <span className="ml-1 border-l pl-1">
+                    {t(`dialog.avatar.performance.ranks.${rating}`, {
+                        defaultValue: rating
+                    })}
+                </span>
             ) : null}
             {fileSize ? (
                 <span className="ml-1 border-l pl-1">{fileSize}</span>

--- a/src/components/dialogs/avatar-dialog/components/AvatarDialogInfoTab.tsx
+++ b/src/components/dialogs/avatar-dialog/components/AvatarDialogInfoTab.tsx
@@ -1,3 +1,4 @@
+import type { TFunction } from 'i18next';
 import { isValidElement, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -20,16 +21,25 @@ import { AvatarDialogTagList } from './AvatarDialogTagList';
 
 const EMPTY_VALUE = '\u2014';
 
-function getPlatformSummary(platformInfo: AvatarPlatformInfo): string {
+function getPlatformSummary(
+    platformInfo: AvatarPlatformInfo,
+    t: TFunction
+): string {
+    const ratingLabel = (rating?: string) =>
+        rating
+            ? t(`dialog.avatar.performance.ranks.${rating}`, {
+                  defaultValue: rating
+              })
+            : '';
     return [
         platformInfo?.pc?.platform
-            ? `PC ${platformInfo.pc.performanceRating || ''}`
+            ? `PC ${ratingLabel(platformInfo.pc.performanceRating)}`
             : '',
         platformInfo?.android?.platform
-            ? `Android ${platformInfo.android.performanceRating || ''}`
+            ? `Android ${ratingLabel(platformInfo.android.performanceRating)}`
             : '',
         platformInfo?.ios?.platform
-            ? `iOS ${platformInfo.ios.performanceRating || ''}`
+            ? `iOS ${ratingLabel(platformInfo.ios.performanceRating)}`
             : ''
     ]
         .filter(Boolean)
@@ -56,7 +66,7 @@ export function AvatarDialogInfoTab({
     const { t } = useTranslation();
 
     const { localTags, contentTags, authorTags, otherTags } = tags;
-    const platformSummary = getPlatformSummary(platformInfo);
+    const platformSummary = getPlatformSummary(platformInfo, t);
 
     return (
         <EntityDialogTabContent value="info" forceMount>

--- a/src/components/dialogs/avatar-dialog/components/AvatarDialogPerformanceTab.test.tsx
+++ b/src/components/dialogs/avatar-dialog/components/AvatarDialogPerformanceTab.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -16,6 +16,9 @@ vi.mock('../../EntityDialogScaffold', () => ({
         <div>{children}</div>
     )
 }));
+
+vi.mock('@/services/entityMediaService', () => ({ openExternalLink: vi.fn() }));
+import { openExternalLink } from '@/services/entityMediaService';
 
 import { AvatarDialogPerformanceTab } from './AvatarDialogPerformanceTab';
 
@@ -87,6 +90,7 @@ describe('AvatarDialogPerformanceTab', () => {
                         avatarStats: {
                             totalPolygons: 123456,
                             totalVertices: 65432,
+                            totalTextureUsage: 32 * 1048576,
                             raycastCount: 4,
                             particleTrailsEnabled: true,
                             particleCollisionEnabled: false
@@ -100,12 +104,22 @@ describe('AvatarDialogPerformanceTab', () => {
         expect(screen.getByText('rating: VeryPoor')).toBeTruthy();
         expect(screen.getByText('12.50 MB')).toBeTruthy();
         expect(screen.getByText('48.25 MB')).toBeTruthy();
-        expect(screen.getByText('32.00 MB')).toBeTruthy();
-        expect(screen.getByText('123,456')).toBeTruthy();
+        expect(screen.getByText('32.00 MB / 150 MB')).toBeTruthy();
+        expect(screen.getByText('123,456 / 70,000').className).toContain(
+            'text-red-700'
+        );
         expect(screen.getByText('65,432')).toBeTruthy();
-        expect(screen.getByText('4')).toBeTruthy();
-        expect(screen.getAllByText('yes')).toHaveLength(1);
-        expect(screen.getAllByText('no')).toHaveLength(1);
+        expect(screen.getByText('4 / 15')).toBeTruthy();
+        expect(screen.getByText('yes / yes').className).toContain(
+            'text-amber-700'
+        );
+        expect(screen.getByText('no / yes').className).toContain(
+            'text-green-700'
+        );
+        fireEvent.click(screen.getByText('pc_rules'));
+        expect(openExternalLink).toHaveBeenCalledWith(
+            'https://creators.vrchat.com/avatars/avatar-performance-ranking-system/#pc-limits'
+        );
     });
 
     it('keeps the rating visible when detailed analysis is unavailable', () => {
@@ -127,4 +141,29 @@ describe('AvatarDialogPerformanceTab', () => {
         expect(screen.getByText('rating: Medium')).toBeTruthy();
         expect(screen.getByText('analysis_unavailable')).toBeTruthy();
     });
+
+    it.each(['android', 'ios'] as const)(
+        'renders mobile limits and documentation for %s',
+        (platform) => {
+            render(
+                <AvatarDialogPerformanceTab
+                    platformInfo={{ pc: {}, android: {}, ios: {} }}
+                    fileAnalysis={{
+                        [platform]: {
+                            avatarStats: { totalPolygons: 18000, lightCount: 0 }
+                        }
+                    }}
+                />
+            );
+            expect(screen.getByText('18,000 / 20,000').className).toContain(
+                'text-orange-700'
+            );
+            expect(
+                screen.getAllByText('mobile_removed').length
+            ).toBeGreaterThan(0);
+            expect(
+                screen.getByText('mobile_rules').getAttribute('href')
+            ).toContain('#mobile-limits');
+        }
+    );
 });

--- a/src/components/dialogs/avatar-dialog/components/AvatarDialogPerformanceTab.tsx
+++ b/src/components/dialogs/avatar-dialog/components/AvatarDialogPerformanceTab.tsx
@@ -6,6 +6,13 @@ import type {
     FileAnalysisRecord,
     PlatformFileAnalysis
 } from '@/domain/entities/world';
+import { openExternalLink } from '@/services/entityMediaService';
+import {
+    assessPerformanceStat,
+    performanceDocsUrl,
+    performanceRankClass,
+    type PerformancePlatform
+} from '@/shared/utils/avatarPerformanceLimits';
 import { Badge } from '@/ui/shadcn/badge';
 import { Spinner } from '@/ui/shadcn/spinner';
 
@@ -121,15 +128,37 @@ function formatStatValue(
         : EMPTY_VALUE;
 }
 
-function PerformanceFact({ label, value }: { label: string; value: string }) {
+function PerformanceFact({
+    label,
+    value,
+    rank,
+    note
+}: {
+    label: string;
+    value: string;
+    rank?: string;
+    note?: string;
+}) {
+    const { t } = useTranslation();
+    const rankLabel = rank
+        ? t(`dialog.avatar.performance.ranks.${rank}`, { defaultValue: rank })
+        : undefined;
     return (
         <div className="bg-muted/40 min-w-0 rounded-md border px-3 py-2">
             <span className="text-muted-foreground block truncate text-xs">
                 {label}
             </span>
-            <span className="mt-0.5 block truncate font-mono text-sm font-medium">
+            <span
+                title={note || rankLabel}
+                className={`mt-0.5 block font-mono text-sm font-medium break-words ${performanceRankClass(rank)}`}
+            >
                 {value || EMPTY_VALUE}
             </span>
+            {note || rank ? (
+                <span className="text-muted-foreground block text-xs">
+                    {note || rankLabel}
+                </span>
+            ) : null}
         </div>
     );
 }
@@ -138,11 +167,13 @@ function PerformanceGroup({
     group,
     stats,
     locale,
+    targetPlatform,
     t
 }: {
     group: PerformanceStatGroup;
     stats: AvatarStatsRecord;
     locale: string;
+    targetPlatform: PerformancePlatform;
     t: TFunction;
 }) {
     return (
@@ -151,20 +182,40 @@ function PerformanceGroup({
                 {t(`dialog.avatar.performance.group.${group.label}`)}
             </h4>
             <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-                {group.stats.map((stat) => (
-                    <PerformanceFact
-                        key={stat.key}
-                        label={t(
-                            `dialog.avatar.performance.stat.${stat.label}`
-                        )}
-                        value={formatStatValue(
-                            stats[stat.key],
-                            stat.format,
-                            locale,
-                            t
-                        )}
-                    />
-                ))}
+                {group.stats.map((stat) => {
+                    const assessment = assessPerformanceStat(
+                        stat.key,
+                        stats[stat.key],
+                        targetPlatform
+                    );
+                    const current = formatStatValue(
+                        stats[stat.key],
+                        stat.format,
+                        locale,
+                        t
+                    );
+                    const value =
+                        assessment.maximum === undefined
+                            ? current
+                            : `${current} / ${formatStatValue(assessment.maximum, stat.format, locale, t)}`;
+                    return (
+                        <PerformanceFact
+                            key={stat.key}
+                            label={t(
+                                `dialog.avatar.performance.stat.${stat.label}`
+                            )}
+                            value={value}
+                            rank={assessment.rank}
+                            note={
+                                assessment.removed
+                                    ? t(
+                                          'dialog.avatar.performance.mobile_removed'
+                                      )
+                                    : undefined
+                            }
+                        />
+                    );
+                })}
             </div>
         </section>
     );
@@ -173,14 +224,21 @@ function PerformanceGroup({
 function PlatformPerformanceSection({
     label,
     platform,
+    targetPlatform,
     analysis
 }: {
     label: string;
     platform: AvatarPlatformInfo['pc'];
+    targetPlatform: PerformancePlatform;
     analysis?: FileAnalysisRecord;
 }) {
     const { t, i18n } = useTranslation();
     const stats = analysis?.avatarStats;
+    const texture = assessPerformanceStat(
+        'totalTextureUsage',
+        stats?.totalTextureUsage,
+        targetPlatform
+    );
     const rating =
         analysis?.performanceRating ||
         platform.performanceRating ||
@@ -190,10 +248,39 @@ function PlatformPerformanceSection({
         <section className="space-y-4 rounded-lg border p-4">
             <div className="flex flex-wrap items-center justify-between gap-2">
                 <h3 className="text-base font-semibold">{label}</h3>
-                <Badge variant="outline">
-                    {t('dialog.avatar.performance.rating')}: {rating}
+                <Badge
+                    variant="outline"
+                    className={performanceRankClass(rating)}
+                >
+                    {t('dialog.avatar.performance.rating')}:{' '}
+                    {t(`dialog.avatar.performance.ranks.${rating}`, {
+                        defaultValue: rating
+                    })}
                 </Badge>
             </div>
+            <p className="text-muted-foreground text-xs">
+                {t('dialog.avatar.performance.limits_help', {
+                    poor: t('dialog.avatar.performance.ranks.Poor'),
+                    good: t('dialog.avatar.performance.ranks.Good'),
+                    medium: t('dialog.avatar.performance.ranks.Medium')
+                })}{' '}
+                <a
+                    href={performanceDocsUrl(targetPlatform)}
+                    className="text-primary underline"
+                    onClick={(event) => {
+                        event.preventDefault();
+                        void openExternalLink(
+                            performanceDocsUrl(targetPlatform)
+                        );
+                    }}
+                >
+                    {t(
+                        targetPlatform === 'pc'
+                            ? 'dialog.avatar.performance.pc_rules'
+                            : 'dialog.avatar.performance.mobile_rules'
+                    )}
+                </a>
+            </p>
             <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
                 <PerformanceFact
                     label={t('dialog.avatar.performance.download_size')}
@@ -205,7 +292,13 @@ function PlatformPerformanceSection({
                 />
                 <PerformanceFact
                     label={t('dialog.avatar.performance.texture_memory')}
-                    value={analysis?._totalTextureUsage || EMPTY_VALUE}
+                    value={
+                        texture.maximum !== undefined &&
+                        analysis?._totalTextureUsage
+                            ? `${analysis._totalTextureUsage} / ${texture.maximum} MB`
+                            : analysis?._totalTextureUsage || EMPTY_VALUE
+                    }
+                    rank={texture.rank}
                 />
             </div>
             {stats ? (
@@ -215,6 +308,7 @@ function PlatformPerformanceSection({
                         group={group}
                         stats={stats}
                         locale={i18n.language || 'en'}
+                        targetPlatform={targetPlatform}
                         t={t}
                     />
                 ))
@@ -239,7 +333,12 @@ export function AvatarDialogPerformanceTab({
     pending?: boolean;
 }) {
     const { t } = useTranslation();
-    const platforms = [
+    const platforms: Array<{
+        key: PerformancePlatform;
+        label: string;
+        platform: AvatarPlatformInfo['pc'];
+        analysis?: FileAnalysisRecord;
+    }> = [
         {
             key: 'pc',
             label: 'PC',
@@ -258,10 +357,13 @@ export function AvatarDialogPerformanceTab({
             platform: platformInfo.ios,
             analysis: fileAnalysis.ios
         }
-    ].filter(({ platform, analysis }) => platform.platform || analysis);
+    ];
+    const availablePlatforms = platforms.filter(
+        ({ platform, analysis }) => platform.platform || analysis
+    );
     const displayedPlatforms = pending
-        ? platforms.filter(({ analysis }) => Boolean(analysis))
-        : platforms;
+        ? availablePlatforms.filter(({ analysis }) => Boolean(analysis))
+        : availablePlatforms;
 
     return (
         <EntityDialogTabContent value="performance">
@@ -284,6 +386,7 @@ export function AvatarDialogPerformanceTab({
                             <PlatformPerformanceSection
                                 key={key}
                                 label={label}
+                                targetPlatform={key}
                                 platform={platform}
                                 analysis={analysis}
                             />

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -4250,6 +4250,17 @@
                 "uncompressed_size": "Uncompressed size",
                 "texture_memory": "Texture memory",
                 "analysis_loading": "Loading detailed performance analysis…",
+                "ranks": {
+                    "Excellent": "Excellent",
+                    "Good": "Good",
+                    "Medium": "Medium",
+                    "Poor": "Poor",
+                    "VeryPoor": "Very Poor"
+                },
+                "limits_help": "Values show current / {poor}-rank maximum, not an upload limit or optimization target. Colors and labels indicate each metric's rank using the published thresholds; the overall rating comes from VRChat. Aim for {good} or {medium}. Unlisted metrics have no rank comparison.",
+                "pc_rules": "PC performance rules ↗",
+                "mobile_rules": "Android / iOS performance rules ↗",
+                "mobile_removed": "Disabled on Android and iOS",
                 "analysis_pending": "Detailed performance analysis is not ready yet. Refresh the avatar to try again.",
                 "analysis_unavailable": "Detailed performance analysis is unavailable for this platform.",
                 "yes": "Yes",

--- a/src/localization/zh-CN.json
+++ b/src/localization/zh-CN.json
@@ -4251,6 +4251,17 @@
                 "uncompressed_size": "解压后大小",
                 "texture_memory": "纹理内存",
                 "analysis_loading": "正在获取详细性能分析…",
+                "ranks": {
+                    "Excellent": "流畅",
+                    "Good": "低负载",
+                    "Medium": "中负载",
+                    "Poor": "高负载",
+                    "VeryPoor": "极高负载"
+                },
+                "limits_help": "数值显示为当前值 / {poor}档上限，并非上传限制或优化目标。颜色和标签按官方阈值表示单项评级；总体评级来自 VRChat。建议以{good}或{medium}为目标；未列出阈值的指标不作评级比较。",
+                "pc_rules": "PC 性能评级规则 ↗",
+                "mobile_rules": "Android / iOS 性能评级规则 ↗",
+                "mobile_removed": "Android 和 iOS 禁用此组件",
                 "analysis_pending": "详细性能分析尚未生成，请稍后刷新 Avatar 重试。",
                 "analysis_unavailable": "此平台暂无详细性能分析数据。",
                 "yes": "是",

--- a/src/shared/utils/avatarPerformanceLimits.test.ts
+++ b/src/shared/utils/avatarPerformanceLimits.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    assessPerformanceStat,
+    performanceDocsUrl
+} from './avatarPerformanceLimits';
+
+describe('avatar performance rank thresholds', () => {
+    it.each([
+        ['totalPolygons', 272878, 70000, 'VeryPoor'],
+        ['meshParticleMaxPolygons', 1584, 5000, 'Medium'],
+        ['physicsColliders', 2, 8, 'Medium'],
+        ['physicsRigidbodies', 1, 8, 'Good'],
+        ['lightCount', 1, 1, 'Poor'],
+        ['particleTrailsEnabled', true, true, 'Medium'],
+        ['particleCollisionEnabled', false, true, 'Excellent'],
+        ['bounds', [2, 2.19, 2], [5, 6, 5], 'Excellent'],
+        ['totalTextureUsage', 58.99 * 1048576, 150, 'Good']
+    ])('matches the in-game PC example for %s', (key, value, maximum, rank) => {
+        expect(assessPerformanceStat(key as string, value, 'pc')).toEqual({
+            maximum,
+            rank
+        });
+    });
+
+    it('keeps exact boundaries in the better rank and checks every bounds axis', () => {
+        expect(assessPerformanceStat('totalPolygons', 70000, 'pc').rank).toBe(
+            'Good'
+        );
+        expect(assessPerformanceStat('totalPolygons', 70001, 'pc').rank).toBe(
+            'VeryPoor'
+        );
+        expect(assessPerformanceStat('bounds', [5, 6, 5], 'pc').rank).toBe(
+            'Medium'
+        );
+        expect(assessPerformanceStat('bounds', [5, 6.01, 5], 'pc').rank).toBe(
+            'VeryPoor'
+        );
+    });
+
+    it.each(['android', 'ios'] as const)(
+        'uses mobile thresholds on %s',
+        (platform) => {
+            expect(
+                assessPerformanceStat('totalPolygons', 15000, platform)
+            ).toEqual({ maximum: 20000, rank: 'Medium' });
+            expect(
+                assessPerformanceStat('physBoneComponentCount', 9, platform)
+                    .rank
+            ).toBe('VeryPoor');
+            expect(
+                assessPerformanceStat('particleTrailsEnabled', true, platform)
+                    .rank
+            ).toBe('Poor');
+            expect(assessPerformanceStat('lightCount', 0, platform)).toEqual({
+                removed: true
+            });
+            expect(performanceDocsUrl(platform)).toContain('#mobile-limits');
+        }
+    );
+
+    it('does not fabricate ratings for missing, malformed or unranked stats', () => {
+        for (const value of [undefined, null, NaN, Infinity, -1, '12', false]) {
+            expect(assessPerformanceStat('totalPolygons', value, 'pc')).toEqual(
+                {}
+            );
+        }
+        expect(assessPerformanceStat('totalVertices', 500, 'pc')).toEqual({});
+        expect(assessPerformanceStat('bounds', [1, 2], 'pc')).toEqual({});
+        expect(assessPerformanceStat('particleTrailsEnabled', 1, 'pc')).toEqual(
+            {}
+        );
+    });
+});

--- a/src/shared/utils/avatarPerformanceLimits.ts
+++ b/src/shared/utils/avatarPerformanceLimits.ts
@@ -1,0 +1,156 @@
+// Official rank maximums, checked 2026-09-07. Keep this table in sync with:
+// https://creators.vrchat.com/avatars/avatar-performance-ranking-system/
+// The displayed denominator is Poor's maximum, not an upload limit or target.
+export const PERFORMANCE_RANKS = [
+    'Excellent',
+    'Good',
+    'Medium',
+    'Poor',
+    'VeryPoor'
+] as const;
+export type PerformanceRank = (typeof PERFORMANCE_RANKS)[number];
+export type PerformancePlatform = 'pc' | 'android' | 'ios';
+type Limits = readonly [number, number, number, number];
+
+const PC: Record<string, Limits> = {
+    totalPolygons: [32000, 70000, 70000, 70000],
+    totalTextureUsage: [40, 75, 110, 150],
+    skinnedMeshCount: [1, 2, 8, 16],
+    meshCount: [4, 8, 16, 24],
+    materialSlotsUsed: [4, 8, 16, 32],
+    physBoneComponentCount: [4, 8, 16, 32],
+    physBoneTransformCount: [16, 64, 128, 256],
+    physBoneColliderCount: [4, 8, 16, 32],
+    physBoneCollisionCheckCount: [32, 128, 256, 512],
+    contactCount: [8, 16, 24, 32],
+    constraintCount: [100, 250, 300, 350],
+    constraintDepth: [20, 50, 80, 100],
+    animatorCount: [1, 4, 16, 32],
+    boneCount: [75, 150, 256, 400],
+    lightCount: [0, 0, 0, 1],
+    particleSystemCount: [0, 4, 8, 16],
+    totalMaxParticles: [0, 300, 1000, 2500],
+    meshParticleMaxPolygons: [0, 1000, 2000, 5000],
+    particleTrailsEnabled: [0, 0, 1, 1],
+    particleCollisionEnabled: [0, 0, 1, 1],
+    trailRendererCount: [1, 2, 4, 8],
+    lineRendererCount: [1, 2, 4, 8],
+    raycastCount: [1, 4, 8, 15],
+    clothCount: [0, 1, 1, 1],
+    totalClothVertices: [0, 50, 100, 200],
+    physicsColliders: [0, 1, 8, 8],
+    physicsRigidbodies: [0, 1, 8, 8],
+    audioSourceCount: [1, 4, 8, 8]
+};
+
+const MOBILE: Record<string, Limits> = {
+    totalPolygons: [7500, 10000, 15000, 20000],
+    totalTextureUsage: [10, 18, 25, 40],
+    skinnedMeshCount: [1, 1, 2, 2],
+    meshCount: [1, 1, 2, 2],
+    materialSlotsUsed: [1, 1, 2, 4],
+    animatorCount: [1, 1, 1, 2],
+    boneCount: [75, 90, 150, 150],
+    physBoneComponentCount: [0, 4, 6, 8],
+    physBoneTransformCount: [0, 16, 32, 64],
+    physBoneColliderCount: [0, 4, 8, 16],
+    physBoneCollisionCheckCount: [0, 16, 32, 64],
+    contactCount: [2, 4, 8, 16],
+    constraintCount: [30, 60, 120, 150],
+    constraintDepth: [5, 15, 35, 50],
+    particleSystemCount: [0, 0, 0, 2],
+    totalMaxParticles: [0, 0, 0, 200],
+    meshParticleMaxPolygons: [0, 0, 0, 400],
+    particleTrailsEnabled: [0, 0, 0, 1],
+    particleCollisionEnabled: [0, 0, 0, 1],
+    trailRendererCount: [0, 0, 0, 1],
+    lineRendererCount: [0, 0, 0, 1],
+    raycastCount: [1, 2, 4, 8]
+};
+
+const MOBILE_REMOVED = new Set([
+    'lightCount',
+    'clothCount',
+    'totalClothVertices',
+    'physicsColliders',
+    'physicsRigidbodies',
+    'audioSourceCount'
+]);
+const BOUNDS = [
+    [2.5, 2.5, 2.5],
+    [4, 4, 4],
+    [5, 6, 5],
+    [5, 6, 5]
+];
+
+export function performanceDocsUrl(platform: PerformancePlatform) {
+    return `https://creators.vrchat.com/avatars/avatar-performance-ranking-system/#${platform === 'pc' ? 'pc' : 'mobile'}-limits`;
+}
+
+export function performanceRankClass(rank: string | undefined) {
+    switch (rank) {
+        case 'Excellent':
+        case 'Good':
+            return 'text-green-700 dark:text-green-400';
+        case 'Medium':
+            return 'text-amber-700 dark:text-amber-400';
+        case 'Poor':
+            return 'text-orange-700 dark:text-orange-400';
+        case 'VeryPoor':
+            return 'text-red-700 dark:text-red-400';
+        default:
+            return '';
+    }
+}
+
+type StatAssessment = {
+    maximum?: number | boolean | number[];
+    rank?: PerformanceRank;
+    removed?: boolean;
+};
+
+// Missing/invalid values and undocumented metrics must not look like zero/Excellent.
+export function assessPerformanceStat(
+    key: string,
+    value: unknown,
+    platform: PerformancePlatform
+): StatAssessment {
+    if (platform !== 'pc' && MOBILE_REMOVED.has(key)) {
+        return { removed: true };
+    }
+    if (key === 'bounds') {
+        if (
+            !Array.isArray(value) ||
+            value.length !== 3 ||
+            !value.every(
+                (v) => typeof v === 'number' && Number.isFinite(v) && v >= 0
+            )
+        ) {
+            return {};
+        }
+        const index = BOUNDS.findIndex((limit) =>
+            value.every((v, axis) => v <= limit[axis]!)
+        );
+        return {
+            maximum: BOUNDS[3],
+            rank: PERFORMANCE_RANKS[index < 0 ? 4 : index]
+        };
+    }
+    const limits = (platform === 'pc' ? PC : MOBILE)[key];
+    if (!limits) return {};
+    const isBoolean =
+        key === 'particleTrailsEnabled' || key === 'particleCollisionEnabled';
+    if (
+        isBoolean
+            ? typeof value !== 'boolean'
+            : typeof value !== 'number' || !Number.isFinite(value) || value < 0
+    ) {
+        return {};
+    }
+    const numeric = Number(value) / (key === 'totalTextureUsage' ? 1048576 : 1);
+    const index = limits.findIndex((limit) => numeric <= limit);
+    return {
+        maximum: isBoolean ? Boolean(limits[3]) : limits[3],
+        rank: PERFORMANCE_RANKS[index < 0 ? 4 : index]
+    };
+}


### PR DESCRIPTION
## What does this PR do?

Avatar performance details currently show raw counts without explaining how they compare with platform limits. This adds current / Poor-rank maximum values, per-metric rank colors and labels, and links to the official PC and Android/iOS rules, following the maintainer's request for this follow-up to #430.

For example, 1,584 mesh-particle triangles on PC now displays as `1,584 / 5,000` with a Medium label and amber color. The denominator is the Poor-rank ceiling, not a recommended optimization target or upload limit. The overall rating still comes from VRChat.

- Keep the documented thresholds together, with source and verification date: https://creators.vrchat.com/avatars/avatar-performance-ranking-system/
- Apply the shared mobile thresholds to Android and iOS, identify disabled mobile components, and leave undocumented or missing metrics unranked.
- Localize rank labels across the performance tab, header badges and platform summary, including the agreed Simplified Chinese terminology. Provide English fallback for other locales.
- Separate the threshold logic and tests from the presentation and localization in two commits.

## How to test

1. Open an avatar with available performance analysis and select Performance.
2. Check current / maximum values, rank labels and colors for PC and mobile platforms. Follow each platform's documentation link.
3. Switch to Simplified Chinese and verify the five labels, the header and platform summary, and the explanatory text.
4. Check that missing statistics are not rated as zero and mobile-only restrictions are identified.

Validation on upstream base `cd2a16210`:
- Passed: format check, TypeScript check, production build, and all 20 focused threshold/component tests.
- Passed: targeted oxlint for all changed TypeScript/TSX files.
- Full `npm run lint` reports an existing unused `userStatusIndicatorClassName` import in `src/components/sidebar/side-panel/SidePanelSelfHeader.tsx:25`, present in the upstream base and unchanged here.
- Verified Simplified Chinese interpolation with the real i18next resources.

## Screenshots

Not captured. The changes have component-test coverage; an authenticated in-app visual review is still needed.
