### PR TITLE
fix(ui): preserve overlays during window restoration

### DIFF
--- a/src/components/layout/AppTitleBar.tsx
+++ b/src/components/layout/AppTitleBar.tsx
@@ -8,6 +8,7 @@ import {
 import type { ComponentProps } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { markAppTitleBarWindowAction } from '@/lib/overlayTitlebar';
 import { cn } from '@/lib/utils';
 import {
     closeWindow,
@@ -43,11 +44,13 @@ function TitleBarWindowButton({
             )}
             onPointerDown={(event: React.PointerEvent) => {
                 if (event.button === 0) {
+                    markAppTitleBarWindowAction();
                     onAction();
                 }
             }}
             onClick={(event: React.MouseEvent) => {
                 if (event.detail === 0) {
+                    markAppTitleBarWindowAction();
                     onAction();
                 }
             }}

--- a/src/components/layout/AppTitleBar.tsx
+++ b/src/components/layout/AppTitleBar.tsx
@@ -50,7 +50,6 @@ function TitleBarWindowButton({
             }}
             onClick={(event: React.MouseEvent) => {
                 if (event.detail === 0) {
-                    markAppTitleBarWindowAction();
                     onAction();
                 }
             }}

--- a/src/lib/overlayTitlebar.test.ts
+++ b/src/lib/overlayTitlebar.test.ts
@@ -1,18 +1,22 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
     markAppTitleBarWindowAction,
     preserveAppTitleBarOnOpenChange
 } from './overlayTitlebar';
 
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+});
+
 describe('preserveAppTitleBarOnOpenChange', () => {
     it('keeps an overlay open when window restoration changes the event target', () => {
         const cancel = vi.fn();
-
         markAppTitleBarWindowAction();
-
         expect(
             preserveAppTitleBarOnOpenChange(false, {
                 reason: 'outside-press',
@@ -21,5 +25,36 @@ describe('preserveAppTitleBarOnOpenChange', () => {
             })
         ).toBe(true);
         expect(cancel).toHaveBeenCalledOnce();
+    });
+
+    it.each(['pointerdown', 'keydown'])(
+        'allows a new interaction after %s during the grace period',
+        (type) => {
+            const cancel = vi.fn();
+            markAppTitleBarWindowAction();
+            document.body.dispatchEvent(new Event(type, { bubbles: true }));
+            expect(
+                preserveAppTitleBarOnOpenChange(false, {
+                    reason: 'outside-press',
+                    event: new Event('click'),
+                    cancel
+                })
+            ).toBe(false);
+            expect(cancel).not.toHaveBeenCalled();
+        }
+    );
+
+    it('expires protection when there is no follow-up event', () => {
+        const cancel = vi.fn();
+        markAppTitleBarWindowAction();
+        vi.advanceTimersByTime(500);
+        expect(
+            preserveAppTitleBarOnOpenChange(false, {
+                reason: 'outside-press',
+                event: new Event('click'),
+                cancel
+            })
+        ).toBe(false);
+        expect(cancel).not.toHaveBeenCalled();
     });
 });

--- a/src/lib/overlayTitlebar.test.ts
+++ b/src/lib/overlayTitlebar.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+    markAppTitleBarWindowAction,
+    preserveAppTitleBarOnOpenChange
+} from './overlayTitlebar';
+
+describe('preserveAppTitleBarOnOpenChange', () => {
+    it('keeps an overlay open when window restoration changes the event target', () => {
+        const cancel = vi.fn();
+
+        markAppTitleBarWindowAction();
+
+        expect(
+            preserveAppTitleBarOnOpenChange(false, {
+                reason: 'outside-press',
+                event: new Event('click'),
+                cancel
+            })
+        ).toBe(true);
+        expect(cancel).toHaveBeenCalledOnce();
+    });
+});

--- a/src/lib/overlayTitlebar.ts
+++ b/src/lib/overlayTitlebar.ts
@@ -1,4 +1,8 @@
 const APP_TITLE_BAR_SELECTOR = '[data-app-titlebar="true"]';
+const WINDOW_ACTION_GRACE_PERIOD_MS = 500;
+
+let pendingWindowAction = false;
+let clearPendingWindowActionTimer: ReturnType<typeof setTimeout> | undefined;
 
 type OverlayCloseEventDetails = {
     reason: string;
@@ -13,19 +17,42 @@ function isAppTitleBarTarget(target: EventTarget | null) {
     );
 }
 
+function markAppTitleBarWindowAction() {
+    pendingWindowAction = true;
+    if (clearPendingWindowActionTimer) {
+        clearTimeout(clearPendingWindowActionTimer);
+    }
+    clearPendingWindowActionTimer = setTimeout(() => {
+        pendingWindowAction = false;
+        clearPendingWindowActionTimer = undefined;
+    }, WINDOW_ACTION_GRACE_PERIOD_MS);
+}
+
+function clearPendingWindowAction() {
+    pendingWindowAction = false;
+    if (clearPendingWindowActionTimer) {
+        clearTimeout(clearPendingWindowActionTimer);
+        clearPendingWindowActionTimer = undefined;
+    }
+}
+
 function preserveAppTitleBarOnOpenChange(
     open: boolean,
     eventDetails: OverlayCloseEventDetails
 ) {
+    const isTitleBarTarget = isAppTitleBarTarget(eventDetails.event.target);
     if (
         !open &&
         eventDetails.reason === 'outside-press' &&
-        isAppTitleBarTarget(eventDetails.event.target)
+        (isTitleBarTarget || pendingWindowAction)
     ) {
         eventDetails.cancel();
+        if (!isTitleBarTarget) {
+            clearPendingWindowAction();
+        }
         return true;
     }
     return false;
 }
 
-export { preserveAppTitleBarOnOpenChange };
+export { markAppTitleBarWindowAction, preserveAppTitleBarOnOpenChange };

--- a/src/lib/overlayTitlebar.ts
+++ b/src/lib/overlayTitlebar.ts
@@ -18,18 +18,23 @@ function isAppTitleBarTarget(target: EventTarget | null) {
 }
 
 function markAppTitleBarWindowAction() {
+    clearPendingWindowAction();
     pendingWindowAction = true;
-    if (clearPendingWindowActionTimer) {
-        clearTimeout(clearPendingWindowActionTimer);
-    }
-    clearPendingWindowActionTimer = setTimeout(() => {
-        pendingWindowAction = false;
-        clearPendingWindowActionTimer = undefined;
-    }, WINDOW_ACTION_GRACE_PERIOD_MS);
+    // A new gesture must clear protection before Base UI's document capture handlers.
+    window.addEventListener('pointerdown', clearPendingWindowAction, true);
+    window.addEventListener('pointercancel', clearPendingWindowAction, true);
+    window.addEventListener('keydown', clearPendingWindowAction, true);
+    clearPendingWindowActionTimer = setTimeout(
+        clearPendingWindowAction,
+        WINDOW_ACTION_GRACE_PERIOD_MS
+    );
 }
 
 function clearPendingWindowAction() {
     pendingWindowAction = false;
+    window.removeEventListener('pointerdown', clearPendingWindowAction, true);
+    window.removeEventListener('pointercancel', clearPendingWindowAction, true);
+    window.removeEventListener('keydown', clearPendingWindowAction, true);
     if (clearPendingWindowActionTimer) {
         clearTimeout(clearPendingWindowActionTimer);
         clearPendingWindowActionTimer = undefined;

--- a/src/services/sidebarAutoHideOverlays.test.tsx
+++ b/src/services/sidebarAutoHideOverlays.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
-import { act, type ReactNode } from 'react';
+import { fireEvent } from '@testing-library/react';
+import { act, type ReactNode, useState } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -103,6 +104,25 @@ function overlay(kind: OverlayKind, open: boolean): ReactNode {
     }
 }
 
+function TitleBarSheetHarness() {
+    const [open, setOpen] = useState(true);
+
+    return (
+        <>
+            <header data-app-titlebar="true">
+                <button type="button">Maximize window</button>
+            </header>
+            <Sheet open={open} modal="trap-focus" onOpenChange={setOpen}>
+                <SheetContent side="right" variant="inset">
+                    <SheetHeader>
+                        <SheetTitle>Notifications</SheetTitle>
+                    </SheetHeader>
+                </SheetContent>
+            </Sheet>
+        </>
+    );
+}
+
 let container: HTMLDivElement;
 let root: Root;
 
@@ -155,4 +175,20 @@ describe('auto-hide with real application overlays', () => {
             }
         }
     );
+
+    it('keeps a sheet open when a title bar control is pressed', async () => {
+        await act(async () => root.render(<TitleBarSheetHarness />));
+
+        const button = container.querySelector('button');
+        expect(button).not.toBeNull();
+        await act(async () => {
+            fireEvent.pointerDown(button!);
+            fireEvent.pointerUp(button!);
+            fireEvent.click(button!);
+        });
+
+        expect(
+            document.querySelector('[data-slot="sheet-popup"]')
+        ).not.toBeNull();
+    });
 });

--- a/src/ui/shadcn/sheet.tsx
+++ b/src/ui/shadcn/sheet.tsx
@@ -6,11 +6,28 @@ import { useRender } from '@base-ui/react/use-render';
 import { XIcon } from 'lucide-react';
 import type React from 'react';
 
+import { preserveAppTitleBarOnOpenChange } from '@/lib/overlayTitlebar';
 import { cn } from '@/lib/utils';
 import { Button } from '@/ui/shadcn/button';
 import { ScrollArea } from '@/ui/shadcn/scroll-area';
 
-export const Sheet: typeof SheetPrimitive.Root = SheetPrimitive.Root;
+export function Sheet({
+    onOpenChange,
+    ...props
+}: SheetPrimitive.Root.Props): React.ReactElement {
+    return (
+        <SheetPrimitive.Root
+            data-slot="sheet"
+            onOpenChange={(open, eventDetails) => {
+                if (preserveAppTitleBarOnOpenChange(open, eventDetails)) {
+                    return;
+                }
+                onOpenChange?.(open, eventDetails);
+            }}
+            {...props}
+        />
+    );
+}
 
 export const SheetPortal: typeof SheetPrimitive.Portal = SheetPrimitive.Portal;
 


### PR DESCRIPTION
## Summary
- prevent sheets from treating title-bar controls as outside presses
- preserve the associated follow-up event when restoring the native window retargets it
- add regression coverage for title-bar overlay interactions

## Testing
- npm run typecheck
- npx vitest run src/lib/overlayTitlebar.test.ts src/services/sidebarAutoHideOverlays.test.tsx