### PR TITLE
fix(direct-access): recognize VRCX-0 share URLs

### DIFF
--- a/src/services/directAccessService.test.ts
+++ b/src/services/directAccessService.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-    handleDeepLinkAction: vi.fn(),
     openInstanceInGame: vi.fn(),
     openWorldDialog: vi.fn()
 }));
@@ -25,10 +24,6 @@ vi.mock('@/services/dialogService', () => ({
 
 vi.mock('@/services/instanceActionService', () => ({
     openInstanceInGame: mocks.openInstanceInGame
-}));
-
-vi.mock('@/services/deepLinkService', () => ({
-    handleDeepLinkAction: mocks.handleDeepLinkAction
 }));
 
 import {
@@ -109,36 +104,6 @@ describe('directAccessParse detect mode', () => {
         expect(mocks.openWorldDialog).not.toHaveBeenCalled();
     });
 
-    it('recognises direct access links embedded in surrounding text', async () => {
-        const links = [
-            `https://open.vrcx-0.dev/world/${WORLD_ID}`,
-            `https://open.vrcx-0.dev/avatar/${AVATAR_ID}`,
-            `https://vrchat.com/home/world/${WORLD_ID}`,
-            'https://vrchat.com/home/user/usr_id',
-            'https://vrchat.com/home/avatar/avtr_id',
-            'https://vrchat.com/home/group/grp_id',
-            'https://vrch.at/abcd1234',
-            'https://vrc.group/vrcx.1234',
-            `vrchat://launch?id=${encodeURIComponent(LOCATION)}`,
-            `vrcx-0://world/open?id=${WORLD_ID}`,
-            `vrcx-0://avatar/open?id=${AVATAR_ID}`,
-            'vrcx-0://collection/import?id=AbC123z',
-            `vrcx://world/${WORLD_ID}`,
-            'vrcx://user/usr_id',
-            'vrcx://avatar/avtr_id',
-            'vrcx://group/grp_id'
-        ];
-
-        for (const link of links) {
-            await expect(
-                directAccessParse(`Copied link: ${link}。`, 'detect')
-            ).resolves.toBe(true);
-        }
-
-        expect(mocks.openInstanceInGame).not.toHaveBeenCalled();
-        expect(mocks.openWorldDialog).not.toHaveBeenCalled();
-    });
-
     it('rejects bare tokens that collide with name searches', async () => {
         await expect(directAccessParse('Kagamine', 'detect')).resolves.toBe(
             false
@@ -158,9 +123,12 @@ describe('directAccessParse detect mode', () => {
             'hello world',
             'https://vrchat.com/home',
             'https://open.vrcx-0.dev/world/wrld_invalid',
+            `http://open.vrcx-0.dev/world/${WORLD_ID}`,
+            `https://open.vrcx-0.dev.example.com/world/${WORLD_ID}`,
+            `https://open.vrcx-0.dev//world/${WORLD_ID}`,
+            `https://open.vrcx-0.dev/world/${WORLD_ID}/extra`,
+            `Open world: https://open.vrcx-0.dev/world/${WORLD_ID}`,
             `https://open.vrcx-0.dev/avatar/${WORLD_ID}`,
-            'Copied link: https://example.com/x',
-            'Copied link: vrcx://addavatardb/https://example.com/avatar-db',
             'https://example.com/x'
         ]) {
             await expect(directAccessParse(value, 'detect')).resolves.toBe(
@@ -173,66 +141,17 @@ describe('directAccessParse detect mode', () => {
         const dialogService = await import('@/services/dialogService');
 
         await expect(
-            directAccessParse(
-                `Open world in VRCX-0: https://open.vrcx-0.dev/world/${WORLD_ID}`
-            )
+            directAccessParse(`https://open.vrcx-0.dev/world/${WORLD_ID}`)
         ).resolves.toBe(true);
         await expect(
-            directAccessParse(
-                `Open avatar in VRCX-0: https://open.vrcx-0.dev/avatar/${AVATAR_ID}`
-            )
+            directAccessParse(`https://open.vrcx-0.dev/avatar/${AVATAR_ID}`)
         ).resolves.toBe(true);
 
         expect(mocks.openWorldDialog).toHaveBeenCalledWith({
-            worldId: WORLD_ID,
-            title: undefined
+            worldId: WORLD_ID
         });
         expect(dialogService.openAvatarDialog).toHaveBeenCalledWith({
             avatarId: AVATAR_ID
-        });
-    });
-
-    it('opens embedded VRCX-0 native deep links', async () => {
-        await expect(
-            directAccessParse(
-                `Open in VRCX-0: vrcx-0://world/open?id=${WORLD_ID}`
-            )
-        ).resolves.toBe(true);
-
-        expect(mocks.handleDeepLinkAction).toHaveBeenCalledWith({
-            type: 'openWorld',
-            worldId: WORLD_ID
-        });
-    });
-
-    it('opens embedded legacy VRCX deep links', async () => {
-        const dialogService = await import('@/services/dialogService');
-
-        await expect(
-            directAccessParse(`Open in VRCX: vrcx://world/${WORLD_ID}`)
-        ).resolves.toBe(true);
-        await expect(
-            directAccessParse('Open in VRCX: vrcx://user/usr_id')
-        ).resolves.toBe(true);
-        await expect(
-            directAccessParse('Open in VRCX: vrcx://avatar/avtr_id')
-        ).resolves.toBe(true);
-        await expect(
-            directAccessParse('Open in VRCX: vrcx://group/grp_id')
-        ).resolves.toBe(true);
-
-        expect(mocks.openWorldDialog).toHaveBeenCalledWith({
-            worldId: WORLD_ID,
-            title: undefined
-        });
-        expect(dialogService.openUserDialog).toHaveBeenCalledWith({
-            userId: 'usr_id'
-        });
-        expect(dialogService.openAvatarDialog).toHaveBeenCalledWith({
-            avatarId: 'avtr_id'
-        });
-        expect(dialogService.openGroupDialog).toHaveBeenCalledWith({
-            groupId: 'grp_id'
         });
     });
 

--- a/src/services/directAccessService.test.ts
+++ b/src/services/directAccessService.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
+    handleDeepLinkAction: vi.fn(),
     openInstanceInGame: vi.fn(),
     openWorldDialog: vi.fn()
 }));
@@ -24,6 +25,10 @@ vi.mock('@/services/dialogService', () => ({
 
 vi.mock('@/services/instanceActionService', () => ({
     openInstanceInGame: mocks.openInstanceInGame
+}));
+
+vi.mock('@/services/deepLinkService', () => ({
+    handleDeepLinkAction: mocks.handleDeepLinkAction
 }));
 
 import {
@@ -114,7 +119,10 @@ describe('directAccessParse detect mode', () => {
             'https://vrchat.com/home/group/grp_id',
             'https://vrch.at/abcd1234',
             'https://vrc.group/vrcx.1234',
-            `vrchat://launch?id=${encodeURIComponent(LOCATION)}`
+            `vrchat://launch?id=${encodeURIComponent(LOCATION)}`,
+            `vrcx-0://world/open?id=${WORLD_ID}`,
+            `vrcx-0://avatar/open?id=${AVATAR_ID}`,
+            'vrcx-0://collection/import?id=AbC123z'
         ];
 
         for (const link of links) {
@@ -176,6 +184,19 @@ describe('directAccessParse detect mode', () => {
         });
         expect(dialogService.openAvatarDialog).toHaveBeenCalledWith({
             avatarId: AVATAR_ID
+        });
+    });
+
+    it('opens embedded VRCX-0 native deep links', async () => {
+        await expect(
+            directAccessParse(
+                `Open in VRCX-0: vrcx-0://world/open?id=${WORLD_ID}`
+            )
+        ).resolves.toBe(true);
+
+        expect(mocks.handleDeepLinkAction).toHaveBeenCalledWith({
+            type: 'openWorld',
+            worldId: WORLD_ID
         });
     });
 

--- a/src/services/directAccessService.test.ts
+++ b/src/services/directAccessService.test.ts
@@ -104,6 +104,29 @@ describe('directAccessParse detect mode', () => {
         expect(mocks.openWorldDialog).not.toHaveBeenCalled();
     });
 
+    it('recognises direct access links embedded in surrounding text', async () => {
+        const links = [
+            `https://open.vrcx-0.dev/world/${WORLD_ID}`,
+            `https://open.vrcx-0.dev/avatar/${AVATAR_ID}`,
+            `https://vrchat.com/home/world/${WORLD_ID}`,
+            'https://vrchat.com/home/user/usr_id',
+            'https://vrchat.com/home/avatar/avtr_id',
+            'https://vrchat.com/home/group/grp_id',
+            'https://vrch.at/abcd1234',
+            'https://vrc.group/vrcx.1234',
+            `vrchat://launch?id=${encodeURIComponent(LOCATION)}`
+        ];
+
+        for (const link of links) {
+            await expect(
+                directAccessParse(`Copied link: ${link}。`, 'detect')
+            ).resolves.toBe(true);
+        }
+
+        expect(mocks.openInstanceInGame).not.toHaveBeenCalled();
+        expect(mocks.openWorldDialog).not.toHaveBeenCalled();
+    });
+
     it('rejects bare tokens that collide with name searches', async () => {
         await expect(directAccessParse('Kagamine', 'detect')).resolves.toBe(
             false
@@ -124,6 +147,7 @@ describe('directAccessParse detect mode', () => {
             'https://vrchat.com/home',
             'https://open.vrcx-0.dev/world/wrld_invalid',
             `https://open.vrcx-0.dev/avatar/${WORLD_ID}`,
+            'Copied link: https://example.com/x',
             'https://example.com/x'
         ]) {
             await expect(directAccessParse(value, 'detect')).resolves.toBe(
@@ -136,10 +160,14 @@ describe('directAccessParse detect mode', () => {
         const dialogService = await import('@/services/dialogService');
 
         await expect(
-            directAccessParse(`https://open.vrcx-0.dev/world/${WORLD_ID}`)
+            directAccessParse(
+                `Open world in VRCX-0: https://open.vrcx-0.dev/world/${WORLD_ID}`
+            )
         ).resolves.toBe(true);
         await expect(
-            directAccessParse(`https://open.vrcx-0.dev/avatar/${AVATAR_ID}`)
+            directAccessParse(
+                `Open avatar in VRCX-0: https://open.vrcx-0.dev/avatar/${AVATAR_ID}`
+            )
         ).resolves.toBe(true);
 
         expect(mocks.openWorldDialog).toHaveBeenCalledWith({

--- a/src/services/directAccessService.test.ts
+++ b/src/services/directAccessService.test.ts
@@ -122,7 +122,11 @@ describe('directAccessParse detect mode', () => {
             `vrchat://launch?id=${encodeURIComponent(LOCATION)}`,
             `vrcx-0://world/open?id=${WORLD_ID}`,
             `vrcx-0://avatar/open?id=${AVATAR_ID}`,
-            'vrcx-0://collection/import?id=AbC123z'
+            'vrcx-0://collection/import?id=AbC123z',
+            `vrcx://world/${WORLD_ID}`,
+            'vrcx://user/usr_id',
+            'vrcx://avatar/avtr_id',
+            'vrcx://group/grp_id'
         ];
 
         for (const link of links) {
@@ -156,6 +160,7 @@ describe('directAccessParse detect mode', () => {
             'https://open.vrcx-0.dev/world/wrld_invalid',
             `https://open.vrcx-0.dev/avatar/${WORLD_ID}`,
             'Copied link: https://example.com/x',
+            'Copied link: vrcx://addavatardb/https://example.com/avatar-db',
             'https://example.com/x'
         ]) {
             await expect(directAccessParse(value, 'detect')).resolves.toBe(
@@ -197,6 +202,37 @@ describe('directAccessParse detect mode', () => {
         expect(mocks.handleDeepLinkAction).toHaveBeenCalledWith({
             type: 'openWorld',
             worldId: WORLD_ID
+        });
+    });
+
+    it('opens embedded legacy VRCX deep links', async () => {
+        const dialogService = await import('@/services/dialogService');
+
+        await expect(
+            directAccessParse(`Open in VRCX: vrcx://world/${WORLD_ID}`)
+        ).resolves.toBe(true);
+        await expect(
+            directAccessParse('Open in VRCX: vrcx://user/usr_id')
+        ).resolves.toBe(true);
+        await expect(
+            directAccessParse('Open in VRCX: vrcx://avatar/avtr_id')
+        ).resolves.toBe(true);
+        await expect(
+            directAccessParse('Open in VRCX: vrcx://group/grp_id')
+        ).resolves.toBe(true);
+
+        expect(mocks.openWorldDialog).toHaveBeenCalledWith({
+            worldId: WORLD_ID,
+            title: undefined
+        });
+        expect(dialogService.openUserDialog).toHaveBeenCalledWith({
+            userId: 'usr_id'
+        });
+        expect(dialogService.openAvatarDialog).toHaveBeenCalledWith({
+            avatarId: 'avtr_id'
+        });
+        expect(dialogService.openGroupDialog).toHaveBeenCalledWith({
+            groupId: 'grp_id'
         });
     });
 

--- a/src/services/directAccessService.test.ts
+++ b/src/services/directAccessService.test.ts
@@ -32,6 +32,7 @@ import {
 } from './directAccessService';
 
 const WORLD_ID = 'wrld_12345678-1234-1234-1234-1234567890ab';
+const AVATAR_ID = 'avtr_12345678-1234-1234-1234-1234567890ab';
 const INSTANCE_ID = '12345~hidden(usr_owner)';
 const LOCATION = `${WORLD_ID}:${INSTANCE_ID}`;
 
@@ -76,6 +77,8 @@ describe('directAccessParse detect mode', () => {
     it('recognises links and prefixed ids without side effects', async () => {
         const cases = [
             `https://vrchat.com/home/world/${WORLD_ID}`,
+            `https://open.vrcx-0.dev/world/${WORLD_ID}`,
+            `https://open.vrcx-0.dev/avatar/${AVATAR_ID}`,
             `https://vrchat.com/home/launch?worldId=${WORLD_ID}`,
             `https://vrchat.com/home/launch?worldId=${WORLD_ID}&instanceId=x`,
             'https://vrchat.com/home/user/usr_id',
@@ -119,12 +122,33 @@ describe('directAccessParse detect mode', () => {
             '   ',
             'hello world',
             'https://vrchat.com/home',
+            'https://open.vrcx-0.dev/world/wrld_invalid',
+            `https://open.vrcx-0.dev/avatar/${WORLD_ID}`,
             'https://example.com/x'
         ]) {
             await expect(directAccessParse(value, 'detect')).resolves.toBe(
                 false
             );
         }
+    });
+
+    it('opens VRCX-0 share links in their matching dialogs', async () => {
+        const dialogService = await import('@/services/dialogService');
+
+        await expect(
+            directAccessParse(`https://open.vrcx-0.dev/world/${WORLD_ID}`)
+        ).resolves.toBe(true);
+        await expect(
+            directAccessParse(`https://open.vrcx-0.dev/avatar/${AVATAR_ID}`)
+        ).resolves.toBe(true);
+
+        expect(mocks.openWorldDialog).toHaveBeenCalledWith({
+            worldId: WORLD_ID,
+            title: undefined
+        });
+        expect(dialogService.openAvatarDialog).toHaveBeenCalledWith({
+            avatarId: AVATAR_ID
+        });
     });
 
     it('keeps mixed case payloads intact', async () => {

--- a/src/services/directAccessService.ts
+++ b/src/services/directAccessService.ts
@@ -11,9 +11,12 @@ import {
     hasAvatarIdPrefix,
     hasGroupIdPrefix,
     hasUserIdPrefix,
-    hasWorldIdPrefix
+    hasWorldIdPrefix,
+    isAvatarId,
+    isWorldId
 } from '@/shared/constants/vrchatIds';
 import { VRCHAT_WEB_BASE } from '@/shared/constants/vrchatWebUrls';
+import { VRCX_OPEN_RELAY_ORIGIN } from '@/shared/constants/vrcxDeepLinks';
 import { parseLocation } from '@/shared/utils/location';
 import { isRecord } from '@/shared/utils/record';
 import { normalizeString } from '@/shared/utils/string';
@@ -29,6 +32,29 @@ function parseUrlOrNull(value: string) {
     } catch {
         return null;
     }
+}
+
+function parseVrcxShareLink(
+    input: string
+): { type: 'avatar' | 'world'; id: string } | null {
+    const url = parseUrlOrNull(input);
+    if (!url || url.origin !== VRCX_OPEN_RELAY_ORIGIN) {
+        return null;
+    }
+
+    const pathParts = url.pathname.split('/').filter(Boolean);
+    if (pathParts.length !== 2) {
+        return null;
+    }
+
+    const [type, id] = pathParts;
+    if (type === 'world' && isWorldId(id)) {
+        return { type, id };
+    }
+    if (type === 'avatar' && isAvatarId(id)) {
+        return { type, id };
+    }
+    return null;
 }
 
 function emptyRecordArray(value: unknown): LooseRecord[] {
@@ -306,6 +332,19 @@ export async function directAccessParse(
     const value = normalizeString(input).trim();
     if (!value) {
         return false;
+    }
+
+    const vrcxShareLink = parseVrcxShareLink(value);
+    if (vrcxShareLink) {
+        if (mode === 'detect') {
+            return true;
+        }
+        if (vrcxShareLink.type === 'world') {
+            openWorldLocation(vrcxShareLink.id);
+        } else {
+            openAvatarDialog({ avatarId: vrcxShareLink.id });
+        }
+        return true;
     }
 
     if (await directAccessWorld(value, mode)) {

--- a/src/services/directAccessService.ts
+++ b/src/services/directAccessService.ts
@@ -26,12 +26,27 @@ export type DirectAccessMode = 'open' | 'detect';
 type LooseRecord = Record<string, unknown>;
 type ParsedLocation = ReturnType<typeof parseLocation>;
 
+const URL_IN_TEXT_RE = /(?:https|vrchat):\/\/[^\s<>"'`]+/giu;
+const TRAILING_URL_PUNCTUATION_RE =
+    /[.,;:!?，。；：！？、)\]}>）】〉》」』]+$/u;
+
 function parseUrlOrNull(value: string) {
     try {
         return new URL(value);
     } catch {
         return null;
     }
+}
+
+function extractLinksFromText(value: string): string[] {
+    const links = new Set<string>();
+    for (const match of value.match(URL_IN_TEXT_RE) ?? []) {
+        const link = match.replace(TRAILING_URL_PUNCTUATION_RE, '');
+        if (link && link !== value) {
+            links.add(link);
+        }
+    }
+    return [...links];
 }
 
 function parseVrcxShareLink(
@@ -422,6 +437,12 @@ export async function directAccessParse(
         }
         openGroupDialog({ groupId: value });
         return true;
+    }
+
+    for (const link of extractLinksFromText(value)) {
+        if (await directAccessParse(link, mode)) {
+            return true;
+        }
     }
 
     return false;

--- a/src/services/directAccessService.ts
+++ b/src/services/directAccessService.ts
@@ -1,7 +1,5 @@
-import type { DeepLinkAction } from '@/platform/tauri/bindings';
 import vrchatInstanceRepository from '@/repositories/vrchatInstanceRepository';
 import vrchatSearchRepository from '@/repositories/vrchatSearchRepository';
-import { handleDeepLinkAction } from '@/services/deepLinkService';
 import {
     openAvatarDialog,
     openGroupDialog,
@@ -9,7 +7,6 @@ import {
     openWorldDialog
 } from '@/services/dialogService';
 import { openInstanceInGame } from '@/services/instanceActionService';
-import { isCollectionShortcode } from '@/shared/constants/collectionShare';
 import {
     hasAvatarIdPrefix,
     hasGroupIdPrefix,
@@ -29,35 +26,12 @@ export type DirectAccessMode = 'open' | 'detect';
 type LooseRecord = Record<string, unknown>;
 type ParsedLocation = ReturnType<typeof parseLocation>;
 
-const URL_IN_TEXT_RE = /(?:https|vrchat|vrcx-0|vrcx):\/\/[^\s<>"'`]+/giu;
-const TRAILING_URL_PUNCTUATION_RE =
-    /[.,;:!?，。；：！？、)\]}>）】〉》」』]+$/u;
-
 function parseUrlOrNull(value: string) {
     try {
         return new URL(value);
     } catch {
         return null;
     }
-}
-
-function decodeUrlPathOrEmpty(value: string): string {
-    try {
-        return decodeURIComponent(value);
-    } catch {
-        return '';
-    }
-}
-
-function extractLinksFromText(value: string): string[] {
-    const links = new Set<string>();
-    for (const match of value.match(URL_IN_TEXT_RE) ?? []) {
-        const link = match.replace(TRAILING_URL_PUNCTUATION_RE, '');
-        if (link && link !== value) {
-            links.add(link);
-        }
-    }
-    return [...links];
 }
 
 function parseVrcxShareLink(
@@ -68,12 +42,12 @@ function parseVrcxShareLink(
         return null;
     }
 
-    const pathParts = url.pathname.split('/').filter(Boolean);
-    if (pathParts.length !== 2) {
+    const pathParts = url.pathname.split('/');
+    if (pathParts.length !== 3) {
         return null;
     }
 
-    const [type, id] = pathParts;
+    const [, type, id] = pathParts;
     if (type === 'world' && isWorldId(id)) {
         return { type, id };
     }
@@ -81,82 +55,6 @@ function parseVrcxShareLink(
         return { type, id };
     }
     return null;
-}
-
-function parseVrcxNativeDeepLink(input: string): DeepLinkAction | null {
-    const url = parseUrlOrNull(input);
-    if (!url || url.protocol !== 'vrcx-0:' || url.hash) {
-        return null;
-    }
-
-    const id = url.searchParams.get('id');
-    if (!id) {
-        return null;
-    }
-
-    if (url.hostname === 'world' && url.pathname === '/open' && isWorldId(id)) {
-        return { type: 'openWorld', worldId: id };
-    }
-    if (
-        url.hostname === 'avatar' &&
-        url.pathname === '/open' &&
-        isAvatarId(id)
-    ) {
-        return { type: 'openAvatar', avatarId: id };
-    }
-    if (
-        url.hostname === 'collection' &&
-        url.pathname === '/import' &&
-        isCollectionShortcode(id)
-    ) {
-        return { type: 'importCollection', collectionId: id };
-    }
-    return null;
-}
-
-function directAccessLegacyVrcxDeepLink(
-    input: string,
-    mode: DirectAccessMode
-): boolean {
-    const url = parseUrlOrNull(input);
-    if (!url || url.protocol !== 'vrcx:') {
-        return false;
-    }
-
-    const id = decodeUrlPathOrEmpty(url.pathname.slice(1));
-    if (!id) {
-        return false;
-    }
-
-    if (url.hostname === 'world' && hasWorldIdPrefix(id)) {
-        if (mode === 'detect') {
-            return true;
-        }
-        openWorldLocation(id);
-        return true;
-    }
-    if (url.hostname === 'user' && hasUserIdPrefix(id)) {
-        if (mode === 'detect') {
-            return true;
-        }
-        openUserDialog({ userId: id });
-        return true;
-    }
-    if (url.hostname === 'avatar' && hasAvatarIdPrefix(id)) {
-        if (mode === 'detect') {
-            return true;
-        }
-        openAvatarDialog({ avatarId: id });
-        return true;
-    }
-    if (url.hostname === 'group' && hasGroupIdPrefix(id)) {
-        if (mode === 'detect') {
-            return true;
-        }
-        openGroupDialog({ groupId: id });
-        return true;
-    }
-    return false;
 }
 
 function emptyRecordArray(value: unknown): LooseRecord[] {
@@ -442,23 +340,10 @@ export async function directAccessParse(
             return true;
         }
         if (vrcxShareLink.type === 'world') {
-            openWorldLocation(vrcxShareLink.id);
+            openWorldDialog({ worldId: vrcxShareLink.id });
         } else {
             openAvatarDialog({ avatarId: vrcxShareLink.id });
         }
-        return true;
-    }
-
-    const vrcxNativeDeepLink = parseVrcxNativeDeepLink(value);
-    if (vrcxNativeDeepLink) {
-        if (mode === 'detect') {
-            return true;
-        }
-        handleDeepLinkAction(vrcxNativeDeepLink);
-        return true;
-    }
-
-    if (directAccessLegacyVrcxDeepLink(value, mode)) {
         return true;
     }
 
@@ -537,12 +422,6 @@ export async function directAccessParse(
         }
         openGroupDialog({ groupId: value });
         return true;
-    }
-
-    for (const link of extractLinksFromText(value)) {
-        if (await directAccessParse(link, mode)) {
-            return true;
-        }
     }
 
     return false;

--- a/src/services/directAccessService.ts
+++ b/src/services/directAccessService.ts
@@ -29,7 +29,7 @@ export type DirectAccessMode = 'open' | 'detect';
 type LooseRecord = Record<string, unknown>;
 type ParsedLocation = ReturnType<typeof parseLocation>;
 
-const URL_IN_TEXT_RE = /(?:https|vrchat|vrcx-0):\/\/[^\s<>"'`]+/giu;
+const URL_IN_TEXT_RE = /(?:https|vrchat|vrcx-0|vrcx):\/\/[^\s<>"'`]+/giu;
 const TRAILING_URL_PUNCTUATION_RE =
     /[.,;:!?，。；：！？、)\]}>）】〉》」』]+$/u;
 
@@ -38,6 +38,14 @@ function parseUrlOrNull(value: string) {
         return new URL(value);
     } catch {
         return null;
+    }
+}
+
+function decodeUrlPathOrEmpty(value: string): string {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return '';
     }
 }
 
@@ -104,6 +112,51 @@ function parseVrcxNativeDeepLink(input: string): DeepLinkAction | null {
         return { type: 'importCollection', collectionId: id };
     }
     return null;
+}
+
+function directAccessLegacyVrcxDeepLink(
+    input: string,
+    mode: DirectAccessMode
+): boolean {
+    const url = parseUrlOrNull(input);
+    if (!url || url.protocol !== 'vrcx:') {
+        return false;
+    }
+
+    const id = decodeUrlPathOrEmpty(url.pathname.slice(1));
+    if (!id) {
+        return false;
+    }
+
+    if (url.hostname === 'world' && hasWorldIdPrefix(id)) {
+        if (mode === 'detect') {
+            return true;
+        }
+        openWorldLocation(id);
+        return true;
+    }
+    if (url.hostname === 'user' && hasUserIdPrefix(id)) {
+        if (mode === 'detect') {
+            return true;
+        }
+        openUserDialog({ userId: id });
+        return true;
+    }
+    if (url.hostname === 'avatar' && hasAvatarIdPrefix(id)) {
+        if (mode === 'detect') {
+            return true;
+        }
+        openAvatarDialog({ avatarId: id });
+        return true;
+    }
+    if (url.hostname === 'group' && hasGroupIdPrefix(id)) {
+        if (mode === 'detect') {
+            return true;
+        }
+        openGroupDialog({ groupId: id });
+        return true;
+    }
+    return false;
 }
 
 function emptyRecordArray(value: unknown): LooseRecord[] {
@@ -402,6 +455,10 @@ export async function directAccessParse(
             return true;
         }
         handleDeepLinkAction(vrcxNativeDeepLink);
+        return true;
+    }
+
+    if (directAccessLegacyVrcxDeepLink(value, mode)) {
         return true;
     }
 

--- a/src/services/directAccessService.ts
+++ b/src/services/directAccessService.ts
@@ -1,5 +1,7 @@
+import type { DeepLinkAction } from '@/platform/tauri/bindings';
 import vrchatInstanceRepository from '@/repositories/vrchatInstanceRepository';
 import vrchatSearchRepository from '@/repositories/vrchatSearchRepository';
+import { handleDeepLinkAction } from '@/services/deepLinkService';
 import {
     openAvatarDialog,
     openGroupDialog,
@@ -7,6 +9,7 @@ import {
     openWorldDialog
 } from '@/services/dialogService';
 import { openInstanceInGame } from '@/services/instanceActionService';
+import { isCollectionShortcode } from '@/shared/constants/collectionShare';
 import {
     hasAvatarIdPrefix,
     hasGroupIdPrefix,
@@ -26,7 +29,7 @@ export type DirectAccessMode = 'open' | 'detect';
 type LooseRecord = Record<string, unknown>;
 type ParsedLocation = ReturnType<typeof parseLocation>;
 
-const URL_IN_TEXT_RE = /(?:https|vrchat):\/\/[^\s<>"'`]+/giu;
+const URL_IN_TEXT_RE = /(?:https|vrchat|vrcx-0):\/\/[^\s<>"'`]+/giu;
 const TRAILING_URL_PUNCTUATION_RE =
     /[.,;:!?，。；：！？、)\]}>）】〉》」』]+$/u;
 
@@ -68,6 +71,37 @@ function parseVrcxShareLink(
     }
     if (type === 'avatar' && isAvatarId(id)) {
         return { type, id };
+    }
+    return null;
+}
+
+function parseVrcxNativeDeepLink(input: string): DeepLinkAction | null {
+    const url = parseUrlOrNull(input);
+    if (!url || url.protocol !== 'vrcx-0:' || url.hash) {
+        return null;
+    }
+
+    const id = url.searchParams.get('id');
+    if (!id) {
+        return null;
+    }
+
+    if (url.hostname === 'world' && url.pathname === '/open' && isWorldId(id)) {
+        return { type: 'openWorld', worldId: id };
+    }
+    if (
+        url.hostname === 'avatar' &&
+        url.pathname === '/open' &&
+        isAvatarId(id)
+    ) {
+        return { type: 'openAvatar', avatarId: id };
+    }
+    if (
+        url.hostname === 'collection' &&
+        url.pathname === '/import' &&
+        isCollectionShortcode(id)
+    ) {
+        return { type: 'importCollection', collectionId: id };
     }
     return null;
 }
@@ -359,6 +393,15 @@ export async function directAccessParse(
         } else {
             openAvatarDialog({ avatarId: vrcxShareLink.id });
         }
+        return true;
+    }
+
+    const vrcxNativeDeepLink = parseVrcxNativeDeepLink(value);
+    if (vrcxNativeDeepLink) {
+        if (mode === 'detect') {
+            return true;
+        }
+        handleDeepLinkAction(vrcxNativeDeepLink);
         return true;
     }
 


### PR DESCRIPTION
## What does this PR do?

Ctrl+D direct access does not recognize VRCX-0 world and avatar share URLs. Parse the input with `new URL()`, require `origin === 'https://open.vrcx-0.dev'`, and validate the ID in `/world/<id>` or `/avatar/<id>` before opening the corresponding dialog. Detection uses the same validation without opening a dialog.

This accepts standalone share URLs; extracting URLs from surrounding text and handling native VRCX protocols are outside this change.

## How to test

Paste a standalone VRCX-0 world or avatar share URL into Ctrl+D and confirm the corresponding dialog opens.

Validated with the direct-access test suite (7 tests), TypeScript typecheck, and formatting checks for the changed files. Tests cover matching entity IDs, incorrect origins, malformed paths, and invalid IDs.

## Screenshots

Not applicable; no visual changes.
