### PR TITLE
refactor(i18n): reordered Korean translation keys

### DIFF
--- a/src/localization/ko.json
+++ b/src/localization/ko.json
@@ -573,6 +573,7 @@
         "friends_locations": "친구 위치",
         "feed": "피드",
         "game_log": "VRChat 로그",
+        "instance_history": "인스턴스 기록",
         "player_list": "플레이어 목록",
         "search": "검색",
         "favorites": "즐겨찾기",
@@ -713,8 +714,10 @@
         "devkit_build_badge": "개발 키트",
         "settings": "설정...",
         "check_updates": "업데이트 확인",
+        "restart": "VRCX-0 다시 시작",
         "start_background_mode": "배경 모드로 전환",
         "logout": "로그아웃",
+        "quit": "VRCX-0 종료",
         "quick_search": "빠른 검색",
         "keyboard_shortcuts": "키보드 단축키",
         "show_friends_sidebar": "친구 사이드바 표시",
@@ -728,11 +731,12 @@
         "report_issue": "문제 보고",
         "community": "커뮤니티",
         "open_source_licenses": "제3자 고지 사항",
+        "about": "VRCX-0 정보",
         "messages": {
             "zoom_failed": "확대/축소를 적용하지 못했습니다.",
-            "open_devtools_failed": "DevTools를 열지 못했습니다.",
             "logout_failed": "VRCX-0에서 로그아웃하지 못했습니다.",
-            "restart_failed": "VRCX-0을(를) 다시 시작하지 못했습니다."
+            "restart_failed": "VRCX-0을(를) 다시 시작하지 못했습니다.",
+            "open_devtools_failed": "DevTools를 열지 못했습니다."
         },
         "label": {
             "started_at": "시작 시간",
@@ -746,10 +750,7 @@
         },
         "action": {
             "close_window": "닫기"
-        },
-        "restart": "VRCX-0 다시 시작",
-        "quit": "VRCX-0 종료",
-        "about": "VRCX-0 정보"
+        }
     },
     "shortcuts": {
         "tray": {
@@ -817,6 +818,7 @@
         "search_clipboard_detected": "클립보드에서 링크 또는 ID를 찾았어요. Enter를 눌러 여세요.",
         "search_joined_groups": "가입된 그룹",
         "refresh_tooltip": "새로고침",
+        "refresh_available_in_seconds": "최근에 동기화되었습니다. {count}초 후에 다시 시도해 주세요.",
         "groups": "그룹",
         "friends": "친구",
         "me": "나",
@@ -862,9 +864,13 @@
             "custom_tabs": {
                 "configure": "탭 사용자 정의",
                 "title": "사이드바 탭 사용자 정의",
-                "display_mode": "탭 표시",
                 "subtitle": "사이드바 탭을 재정렬하거나 즐겨찾기 그룹으로 새 탭을 만들어 보세요.",
+                "display_mode": "탭 표시",
                 "display_hint": "사이드바에서 탭이 표시되는 방식.",
+                "display_auto": "자동",
+                "display_icon_text": "아이콘 + 텍스트",
+                "display_icon_only": "아이콘만",
+                "tab_layout": "탭",
                 "layout_hint": "드래그해서 순서를 바꿀 수 있어요. 친구와 그룹은 기본 탭이며, 즐겨찾기 그룹을 나만의 탭으로 추가할 수 있어요.",
                 "system_badge": "기본",
                 "always_visible": "항상 표시",
@@ -872,20 +878,16 @@
                 "move_down": "아래로 이동",
                 "delete_tab": "탭 삭제",
                 "favorite_groups_summary": "즐겨찾기 그룹",
-                "display_auto": "자동",
-                "display_icon_text": "아이콘 + 텍스트",
-                "display_icon_only": "아이콘만",
-                "tab_layout": "탭",
                 "tab_name": "탭 이름",
                 "visible": "보이는",
                 "hide_tab": "탭 숨기기",
                 "hide_groups": "그룹 숨기기",
                 "add_favorite_tab": "즐겨찾기 탭 추가",
                 "favorite_collection_default": "좋아하는 컬렉션",
+                "remote_groups": "VRChat 즐겨찾는 그룹",
                 "local_groups": "로컬 즐겨찾기 그룹",
                 "no_favorite_groups": "즐겨찾는 그룹이 로드되지 않았습니다.",
                 "empty_favorite_collection": "이 즐겨찾는 탭에는 친구가 없습니다.",
-                "remote_groups": "VRChat 즐겨찾는 그룹",
                 "dynamic": {
                     "drag_value": "{value} 드래그",
                     "icon_for_value": "{value} 아이콘",
@@ -912,22 +914,25 @@
             "no_unseen_notifications": "읽지 않은 알림 없음"
         },
         "success": {
+            "vrchat_launch_request_sent": "VRChat에서 열었습니다.",
             "invite_request_sent": "초대 요청이 전송되었습니다.",
             "boop_sent": "부프를 보냈습니다",
-            "friend_and_favorite_snapshots_refreshed": "친구가 새로고침되었습니다.",
-            "vrchat_launch_request_sent": "VRChat에서 열었습니다."
+            "friend_and_favorite_snapshots_refreshed": "친구가 새로고침되었습니다."
         },
         "error": {
+            "unable_to_open_this_instance_in_vrchat": "VRChat에서 이 인스턴스를 열 수 없습니다.",
+            "cannot_invite_no_current_vrchat_location_is_available": "초대할 수 없습니다. 현재 VRChat 위치를 사용할 수 없습니다.",
             "cannot_invite_from_the_current_instance_type": "현재 인스턴스 유형에서는 초대할 수 없습니다.",
             "cannot_invite_current_location_is_not_a_concrete_instance": "초대할 수 없습니다. 현재 위치는 구체적인 인스턴스가 아닙니다.",
-            "cannot_update_profile_no_current_user_session_is_available": "프로필을 업데이트할 수 없습니다. 현재 사용자 세션을 사용할 수 없습니다.",
-            "unable_to_open_this_instance_in_vrchat": "VRChat에서 이 인스턴스를 열 수 없습니다.",
-            "cannot_invite_no_current_vrchat_location_is_available": "초대할 수 없습니다. 현재 VRChat 위치를 사용할 수 없습니다."
+            "cannot_update_profile_no_current_user_session_is_available": "프로필을 업데이트할 수 없습니다. 현재 사용자 세션을 사용할 수 없습니다."
         },
         "empty": {
             "no_authenticated_user_snapshot_is_available": "친구를 새로 고치기 전에 로그인하세요"
-        },
-        "refresh_available_in_seconds": "최근에 동기화되었습니다. {count}초 후에 다시 시도해 주세요."
+        }
+    },
+    "support_vrcx": {
+        "title": "VRCX-0 후원",
+        "description": "GitHub Sponsors 또는 Ko-fi를 통해 향후 VRCX-0 개발을 후원해 주세요."
     },
     "view": {
         "login": {
@@ -939,10 +944,15 @@
             "useOtherAccount": "다른 계정으로 로그인",
             "backToSavedAccounts": "저장된 계정 목록으로 돌아가기",
             "proxy_settings": "프록시 설정",
+            "proxy_description": "로그인 전에 사용되는 프록시 서버를 설정합니다. 127.0.0.1:7890, http://127.0.0.1:7890, 및 socks5://127.0.0.1:7890을 지원합니다.",
             "field": {
                 "username": "닉네임 혹은 이메일",
                 "password": "비밀번호",
                 "saveCredentials": "로그인 정보 저장"
+            },
+            "placeholder": {
+                "account": "VRChat 계정",
+                "password": "VRChat 비밀번호"
             },
             "validation": {
                 "username_required": "사용자 이름 또는 이메일이 필요합니다",
@@ -950,14 +960,9 @@
             },
             "saved_account_remove": {
                 "title": "저장된 계정 삭제",
+                "description": "{name}이(가) 삭제됩니다",
                 "confirm": "제거",
-                "removing": "삭제 중...",
-                "description": "{name}이(가) 삭제됩니다"
-            },
-            "proxy_description": "로그인 전에 사용되는 프록시 서버를 설정합니다. 127.0.0.1:7890, http://127.0.0.1:7890, 및 socks5://127.0.0.1:7890을 지원합니다.",
-            "placeholder": {
-                "account": "VRChat 계정",
-                "password": "VRChat 비밀번호"
+                "removing": "삭제 중..."
             }
         },
         "feed": {
@@ -972,12 +977,12 @@
             "search_placeholder": "검색",
             "date_range": "기간",
             "filters": {
+                "GPS": "GPS",
                 "Online": "온라인",
                 "Offline": "오프라인",
                 "Status": "상태",
                 "Avatar": "아바타",
-                "Bio": "바이오",
-                "GPS": "GPS"
+                "Bio": "바이오"
             },
             "toolbar": {
                 "all_types": "전체",
@@ -1012,7 +1017,9 @@
                 "all_friends": "모든 친구",
                 "all_favorites": "모든 즐겨찾는 그룹",
                 "selected_favorites": "선택한 즐겨찾는 그룹",
+                "groups_count": "{count} 그룹",
                 "except_all_favorites": "모든 즐겨찾기 제외",
+                "except_groups_count": "{count} 그룹 제외",
                 "exclude_favorites": "즐겨찾는 그룹 제외",
                 "exclude_none": "제외하지 마세요",
                 "exclude_all_favorites": "모든 즐겨찾는 그룹",
@@ -1023,19 +1030,17 @@
                 "restore_preset": "사전 설정 복원",
                 "restore_preset_title": "피드 열 사전 설정을 복원하시겠습니까?",
                 "restore_preset_description": "즐겨찾기, 위치, 프로필, 현재 상태 등 미리 설정된 열이 복원됩니다.",
-                "restore_preset_confirm": "사전 설정 복원",
-                "groups_count": "{count} 그룹",
-                "except_groups_count": "{count} 그룹 제외"
+                "restore_preset_confirm": "사전 설정 복원"
             },
             "error": {
                 "avatar_author_unavailable": "아바타 작성자를 사용할 수 없습니다.",
                 "avatar_is_private_or_not_found": "아바타가 비공개이거나 찾을 수 없습니다.",
+                "unable_to_open_this_instance_in_vrchat": "VRChat에서 이 인스턴스를 열 수 없습니다.",
+                "cannot_invite_no_current_vrchat_location_is_available": "초대할 수 없습니다. 현재 VRChat 위치를 사용할 수 없습니다.",
                 "cannot_invite_from_the_current_instance_type": "현재 인스턴스 유형에서는 초대할 수 없습니다.",
                 "cannot_invite_current_location_is_not_a_concrete_instance": "초대할 수 없습니다. 현재 위치는 구체적인 인스턴스가 아닙니다.",
                 "cannot_request_invite_friend_is_not_online": "초대를 요청할 수 없습니다. 친구가 온라인 상태가 아닙니다.",
-                "feed_query_failed": "피드를 불러오지 못했습니다.",
-                "unable_to_open_this_instance_in_vrchat": "VRChat에서 이 인스턴스를 열 수 없습니다.",
-                "cannot_invite_no_current_vrchat_location_is_available": "초대할 수 없습니다. 현재 VRChat 위치를 사용할 수 없습니다."
+                "feed_query_failed": "피드를 불러오지 못했습니다."
             },
             "label": {
                 "previous_avatar": "이전 아바타",
@@ -1045,9 +1050,9 @@
                 "favorites_only": "즐겨찾기만"
             },
             "success": {
+                "vrchat_launch_request_sent": "VRChat에서 열었습니다.",
                 "invite_request_sent": "초대 요청이 전송되었습니다.",
-                "boop_sent": "부프를 보냈습니다",
-                "vrchat_launch_request_sent": "VRChat에서 열었습니다."
+                "boop_sent": "부프를 보냈습니다"
             },
             "loading": {
                 "loading_feed_rows": "피드 행 로드 중"
@@ -1096,11 +1101,11 @@
             "show_same_instance_in_online": "온라인에서 동일한 인스턴스 표시",
             "loading_more": "더 로드 중...",
             "busy": "바쁨",
+            "local_group": "로컬: {name}",
             "all_matching_friends": "일치하는 모든 친구",
             "no_favorite_group": "좋아하는 그룹 없음",
             "favorite_group_segment": "좋아하는 그룹 세그먼트",
-            "friend_is_not_in_hydrated_favorite_group": "이 친구의 즐겨찾는 그룹이 아직 로드되지 않았습니다.",
-            "local_group": "로컬: {name}"
+            "friend_is_not_in_hydrated_favorite_group": "이 친구의 즐겨찾는 그룹이 아직 로드되지 않았습니다."
         },
         "game_log": {
             "filters": {
@@ -1115,16 +1120,16 @@
                 "ImageLoad": "이미지 로드"
             },
             "sessions": {
+                "friends_count": "친구 {count}명",
+                "play_count": "×{count}",
                 "videos": "비디오",
                 "unknown_user": "알 수 없는 사용자",
                 "unknown_video": "알 수 없는 동영상",
+                "played_by": "{name}님이 재생함",
                 "expand_session": "세션 확장",
                 "collapse_session": "세션 축소",
                 "expand_all": "모두 펼치기",
-                "collapse_all": "모두 접기",
-                "friends_count": "친구 {count}명",
-                "play_count": "×{count}",
-                "played_by": "{name}님이 재생함"
+                "collapse_all": "모두 접기"
             },
             "label": {
                 "sessions": "세션",
@@ -1166,9 +1171,9 @@
                 "broaden_the_filters_or_search_query_to_see_more_results": "더 많은 결과를 보려면 필터나 검색어를 확장하세요."
             },
             "toast": {
+                "failed_to_look_up_value": "{value}을(를) 조회하지 못했습니다.",
                 "failed_to_delete_game_log_row": "게임 로그 항목을 삭제하지 못했습니다.",
-                "failed_to_load_instance_history": "인스턴스 기록을 로드하지 못했습니다.",
-                "failed_to_look_up_value": "{value}을(를) 조회하지 못했습니다."
+                "failed_to_load_instance_history": "인스턴스 기록을 로드하지 못했습니다."
             },
             "modal": {
                 "delete_game_log_row": "게임 로그 항목을 삭제할까요?"
@@ -1178,14 +1183,30 @@
             }
         },
         "instance_history": {
+            "mode": {
+                "search": "검색",
+                "day": "일별"
+            },
+            "day": {
+                "expand_chart": "활동 차트 펼치기",
+                "collapse_chart": "활동 차트 접기"
+            },
+            "placeholder": {
+                "user": "사용자 선택"
+            },
             "label": {
+                "selected_user": "선택한 사용자",
+                "unnamed_user": "이름 없는 사용자",
+                "self": "나",
                 "date_range": "날짜 범위",
                 "start": "시작",
                 "end": "종료"
             },
-            "mode": {
-                "search": "검색",
-                "day": "일별"
+            "action": {
+                "open_full": "전체 인스턴스 기록 열기"
+            },
+            "toast": {
+                "failed_to_load_instance_history": "인스턴스 기록을 불러오지 못했습니다"
             }
         },
         "my_avatars": {
@@ -1320,11 +1341,11 @@
             "avatars": {
                 "search": "검색",
                 "vrchat_favorites": "VRChat 즐겨찾기",
+                "local_favorites": "로컬 즐겨찾기(VRC+)",
                 "new_group": "새 그룹",
                 "local_history": "로컬 기록",
                 "styles": "스타일",
-                "almost_nuisance": "거의 귀찮은 사용자",
-                "local_favorites": "로컬 즐겨찾기(VRC+)"
+                "almost_nuisance": "거의 귀찮은 사용자"
             },
             "select_all": "모두 선택",
             "deselect_all": "모두 선택 취소",
@@ -1346,6 +1367,10 @@
                 "favorited": "즐겨찾기",
                 "favorite_added": "즐겨찾기가 추가되었습니다",
                 "local_favorite_added": "로컬 즐겨찾기 추가됨",
+                "vrchat_favorites": "VRChat 즐겨찾기",
+                "review_the_csv_content_before_copying_it_to_the_clipboard": "클립보드에 복사하기 전에 CSV 콘텐츠를 검토하세요.",
+                "vrchat_group": "VRChat 그룹",
+                "all_vrchat_favorites": "모든 VRChat 즐겨찾기",
                 "local_group": "로컬 그룹",
                 "item_s": "품목",
                 "sort_favorites": "즐겨찾기 정렬",
@@ -1358,10 +1383,6 @@
                 "local_favorite_group_renamed": "로컬 즐겨찾는 그룹 이름이 변경됨",
                 "the_favorites_baseline_did_not_finish_loading": "즐겨찾기를 모두 불러오지 못했습니다.",
                 "try_a_different_search_term": "다른 검색어를 사용해 보세요.",
-                "vrchat_favorites": "VRChat 즐겨찾기",
-                "review_the_csv_content_before_copying_it_to_the_clipboard": "클립보드에 복사하기 전에 CSV 콘텐츠를 검토하세요.",
-                "vrchat_group": "VRChat 그룹",
-                "all_vrchat_favorites": "모든 VRChat 즐겨찾기",
                 "online_favorites_copy_hint": "온라인 즐겨찾기는 온라인 그룹 간에만 이동할 수 있습니다. 이미 온라인에 즐겨찾기된 항목은 다른 온라인 그룹으로 복사할 수 없습니다."
             },
             "success": {
@@ -1369,18 +1390,18 @@
                 "local_favorite_removed": "로컬 즐겨찾기가 삭제되었습니다.",
                 "copied_favorite_export_data": "즐겨찾는 내보내기 데이터를 복사했습니다.",
                 "favorites_refreshed": "즐겨찾기가 새로고침되었습니다.",
+                "vrchat_favorite_removed": "VRChat 즐겨찾기가 삭제되었습니다.",
                 "favorite_group_cleared": "즐겨찾는 그룹이 삭제되었습니다.",
                 "local_favorite_group_deleted": "로컬 즐겨찾는 그룹이 삭제되었습니다.",
                 "avatar_history_cleared": "아바타 기록이 삭제되었습니다.",
+                "vrchat_launch_request_sent": "VRChat에서 열었습니다.",
                 "invite_request_sent": "초대 요청이 전송되었습니다.",
                 "boop_sent": "부프를 보냈습니다",
                 "avatar_selected": "아바타가 선택됨",
                 "copied_selected_favorite_ids": "선택한 즐겨찾기 ID를 복사했습니다.",
                 "selected_favorites_removed": "선택한 즐겨찾기가 삭제되었습니다.",
                 "selected_favorites_moved": "선택한 즐겨찾기를 이동했습니다.",
-                "selected_favorites_copied": "선택한 즐겨찾기를 복사했습니다.",
-                "vrchat_favorite_removed": "VRChat 즐겨찾기가 삭제되었습니다.",
-                "vrchat_launch_request_sent": "VRChat에서 열었습니다."
+                "selected_favorites_copied": "선택한 즐겨찾기를 복사했습니다."
             },
             "action": {
                 "remove_favorite": "즐겨찾기 삭제",
@@ -1398,12 +1419,12 @@
                 "the_selected_group_currently_has_no_items": "선택한 그룹에는 현재 항목이 없습니다."
             },
             "error": {
+                "unable_to_open_this_instance_in_vrchat": "VRChat에서 이 인스턴스를 열 수 없습니다.",
                 "cannot_self_invite_to_this_instance": "이 인스턴스에 직접 초대할 수 없습니다.",
+                "cannot_invite_no_current_vrchat_location_is_available": "초대할 수 없습니다. 현재 VRChat 위치를 사용할 수 없습니다.",
                 "cannot_invite_from_the_current_instance_type": "현재 인스턴스 유형에서는 초대할 수 없습니다.",
                 "cannot_invite_current_location_is_not_a_concrete_instance": "초대할 수 없습니다. 현재 위치는 구체적인 인스턴스가 아닙니다.",
-                "favorites_failed_to_load": "즐겨찾기를 로드하지 못했습니다.",
-                "unable_to_open_this_instance_in_vrchat": "VRChat에서 이 인스턴스를 열 수 없습니다.",
-                "cannot_invite_no_current_vrchat_location_is_available": "초대할 수 없습니다. 현재 VRChat 위치를 사용할 수 없습니다."
+                "favorites_failed_to_load": "즐겨찾기를 로드하지 못했습니다."
             },
             "loading": {
                 "loading_favorites_baseline": "즐겨찾기 불러오는 중",
@@ -1611,10 +1632,10 @@
                 "notification_log_entry_deleted": "알림을 기록에서 삭제했습니다."
             },
             "error": {
+                "cannot_invite_no_current_vrchat_location_is_available": "초대할 수 없습니다. 현재 VRChat 위치를 사용할 수 없습니다.",
                 "cannot_invite_from_the_current_instance_type": "현재 인스턴스 유형에서는 초대할 수 없습니다.",
                 "cannot_invite_current_location_is_not_a_concrete_instance": "초대할 수 없습니다. 현재 위치는 구체적인 인스턴스가 아닙니다.",
-                "cannot_send_invite_response_no_current_user_session_is_available": "초대 응답을 보낼 수 없습니다. 현재 사용자 세션을 사용할 수 없습니다.",
-                "cannot_invite_no_current_vrchat_location_is_available": "초대할 수 없습니다. 현재 VRChat 위치를 사용할 수 없습니다."
+                "cannot_send_invite_response_no_current_user_session_is_available": "초대 응답을 보낼 수 없습니다. 현재 사용자 세션을 사용할 수 없습니다."
             },
             "empty": {
                 "no_custom_emoji_selected_the_default_boop_will_be_sent": "맞춤 이모티콘을 선택하지 않았습니다. 기본 부프가 전송됩니다."
@@ -1675,9 +1696,9 @@
             "success": {
                 "friend_detail_loading_cancelled": "친구 세부정보 로드가 취소되었습니다.",
                 "roster_bootstrap_did_not_complete": "친구를 불러오지 못했습니다.",
+                "vrchat_launch_request_sent": "VRChat에서 열었습니다.",
                 "invite_request_sent": "초대 요청이 전송되었습니다.",
-                "boop_sent": "부프를 보냈습니다",
-                "vrchat_launch_request_sent": "VRChat에서 열었습니다."
+                "boop_sent": "부프를 보냈습니다"
             },
             "empty": {
                 "no_friends_are_available_for_mutual_friends_loading": "서로 친구를 불러오는 데 사용할 수 있는 친구가 없습니다.",
@@ -1691,11 +1712,11 @@
             "error": {
                 "friend_roster_failed_to_load": "친구 명단을 로드하지 못했습니다.",
                 "failed_to_load_friend_details": "친구 상세 정보를 불러오지 못했습니다.",
+                "unable_to_open_this_instance_in_vrchat": "VRChat에서 이 인스턴스를 열 수 없습니다.",
+                "cannot_invite_no_current_vrchat_location_is_available": "초대할 수 없습니다. 현재 VRChat 위치를 사용할 수 없습니다.",
                 "cannot_invite_from_the_current_instance_type": "현재 인스턴스 유형에서는 초대할 수 없습니다.",
                 "cannot_invite_current_location_is_not_a_concrete_instance": "초대할 수 없습니다. 현재 위치는 구체적인 인스턴스가 아닙니다.",
-                "friend_locations_failed_to_load": "친구 위치를 로드하지 못했습니다.",
-                "unable_to_open_this_instance_in_vrchat": "VRChat에서 이 인스턴스를 열 수 없습니다.",
-                "cannot_invite_no_current_vrchat_location_is_available": "초대할 수 없습니다. 현재 VRChat 위치를 사용할 수 없습니다."
+                "friend_locations_failed_to_load": "친구 위치를 로드하지 못했습니다."
             },
             "description": {
                 "cancelling": "취소 중..."
@@ -1866,46 +1887,51 @@
                 "my_groups": "내 그룹",
                 "my_groups_description": "가입한 그룹의 순서, 공개 범위, 탈퇴를 관리합니다."
             },
+            "user": {
+                "discord_names_description": "VRChat 친구의 Discord 사용자 이름 찾기",
+                "export_friend_list_description": "VRChat에서 친구 목록 내보내기",
+                "export_own_avatars_description": "VRChat에서 개인 아바타 내보내기"
+            },
             "export": {
                 "header": "수출",
                 "export_notes": "사용자 로컬 메모 내보내기",
+                "export_notes_description": "VRCX-0 메모를 VRChat 메모로 내보내기",
                 "discord_names": "디스코드 아이디",
                 "export_friend_list": "친구 목록 내보내기",
-                "export_own_avatars": "내 아바타 목록 내보내기",
-                "export_notes_description": "VRCX-0 메모를 VRChat 메모로 내보내기"
+                "export_own_avatars": "내 아바타 목록 내보내기"
             },
             "pictures": {
-                "header": "미디어",
-                "screenshot": "스크린샷",
-                "screenshot_description": "VRChat 사진과 촬영 정보 둘러보기",
-                "gallery": "갤러리",
-                "inventory": "인벤토리",
-                "inventory_description": "이모티콘, 스티커, 아이템, 코스메틱 관리",
                 "pictures": {
                     "vrc_photos": "VRChat 사진",
                     "steam_screenshots": "Steam 스크린샷",
                     "vrc_photos_description": "VRChat 사진 폴더를 엽니다.",
                     "steam_screenshots_description": "Steam 스크린샷 폴더를 엽니다."
                 },
-                "gallery_description": "VRChat 갤러리 관리 — 사진, 프로필 아이콘, 프린트"
+                "header": "미디어",
+                "screenshot": "스크린샷",
+                "screenshot_description": "VRChat 사진과 촬영 정보 둘러보기",
+                "gallery": "갤러리",
+                "gallery_description": "VRChat 갤러리 관리 — 사진, 프로필 아이콘, 프린트",
+                "inventory": "인벤토리",
+                "inventory_description": "이모티콘, 스티커, 아이템, 코스메틱 관리"
             },
             "shortcuts": {
                 "header": "폴더",
-                "crash_dumps": "크래시 덤프",
                 "vrcx_data": "VRCX-0 데이터",
                 "vrcx_data_description": "VRCX-0 데이터 폴더를 엽니다.",
                 "vrchat_data": "VRChat 데이터",
                 "vrchat_data_description": "VRChat 데이터 폴더를 엽니다.",
+                "crash_dumps": "크래시 덤프",
                 "crash_dumps_description": "VRChat 크래시 덤프 폴더를 엽니다."
             },
             "system_tools": {
-                "app_launcher": "앱 런처",
                 "header": "VRChat 및 시스템",
                 "vrchat_config": "VRChat 구성",
                 "vrchat_config_description": "VRChat 설정 열기",
                 "vrchat_log": "VRChat 로그 뷰어",
                 "vrchat_log_description": "로컬 VRChat 출력 로그 읽기",
                 "launch_options_description": "VRChat 실행 옵션 편집",
+                "app_launcher": "앱 런처",
                 "app_launcher_description": "VRChat 시작 시 앱을 자동 실행합니다.",
                 "registry_backup": "VRChat 레지스트리 백업",
                 "registry_backup_description": "VRChat 레지스트리 백업 생성 또는 복원",
@@ -1913,6 +1939,7 @@
                 "llm_endpoints_description": "Social AI 및 번역에 사용하는 AI 서비스 연결을 관리합니다."
             },
             "vrchat_log": {
+                "title": "VRChat 로그 뷰어",
                 "latest": "최신",
                 "file_placeholder": "로그 파일 선택",
                 "search_placeholder": "메시지, 카테고리 또는 스택 추적 검색",
@@ -1924,31 +1951,33 @@
                 "clear_selected": "선택 항목 지우기",
                 "copied": "로그 텍스트를 클립보드에 복사했습니다.",
                 "copy_failed": "로그 텍스트를 복사하지 못했습니다.",
+                "continuation_count": "+{count} 라인",
                 "column_time": "시간",
                 "column_level": "레벨",
                 "column_category": "카테고리",
                 "column_message": "메시지",
                 "loading": "로그 항목 로드 중",
                 "load_more": "더 로드하기",
-                "no_entries": "현재 필터와 일치하는 항목이 없습니다.",
-                "no_entries_description": "수준, 카테고리 또는 검색 텍스트를 조정합니다.",
-                "no_category": "카테고리 없음",
-                "error_tail": "새 로그 항목을 읽지 못했습니다.",
-                "title": "VRChat 로그 뷰어",
-                "continuation_count": "+{count} 라인",
                 "unavailable": "VRChat 데이터 폴더를 사용할 수 없습니다.",
                 "no_files": "VRChat 출력 로그를 찾을 수 없습니다.",
                 "no_files_description": "VRChat을(를) 한 번 시작하고 output_log_*.txt가 나타난 후 이 페이지를 새로 고치세요.",
+                "no_entries": "현재 필터와 일치하는 항목이 없습니다.",
+                "no_entries_description": "수준, 카테고리 또는 검색 텍스트를 조정합니다.",
+                "no_category": "카테고리 없음",
                 "error_load_files": "VRChat 로그 파일을 로드하지 못했습니다.",
                 "error_load_entries": "VRChat 로그 항목을 로드하지 못했습니다.",
+                "error_tail": "새 로그 항목을 읽지 못했습니다.",
                 "loaded_count": "{loaded} / {total} 로드됨",
                 "selected_count": "{count} 선택됨"
             },
             "social_automation": {
                 "header": "소셜 자동화",
                 "status_schedule": "현황 일정",
+                "status_schedule_description": "상태 변경을 예약합니다. VRChat 실행 중에만 동작하도록 제한할 수 있습니다.",
                 "room_status_rules": "인스턴스·월드 상태 규칙",
+                "room_status_rules_description": "인스턴스, 월드, 친구에 따라 상태를 자동 변경합니다.",
                 "invite_request_auto_reply": "초대 요청 자동 응답",
+                "invite_request_auto_reply_description": "VRChat 실행 중 참여를 요청하는 승인된 친구를 자동으로 초대합니다.",
                 "schedule_rules": "일정 규칙",
                 "schedule_rules_description": "기간은 상태, 상태 메시지 또는 둘 다를 변경할 수 있습니다.",
                 "add_rule": "규칙 추가",
@@ -1967,6 +1996,7 @@
                 "run_every_day_hint": "매일 실행하려면 모두 선택하지 않은 상태로 둡니다.",
                 "same_start_end_hint": "시작과 종료 시간이 같으면 하루 종일 적용됩니다.",
                 "only_when_game_running": "게임 중에만",
+                "only_when_game_running_description": "VRChat이 실행되고 있지 않으면 이 규칙을 건너뜁니다.",
                 "restore_previous_status": "이전 상태 복원",
                 "restore_previous_status_description": "기간이 끝나면 상태를 되돌립니다. 예약된 값을 유지하려면 끄세요.",
                 "status": "상태",
@@ -2003,17 +2033,13 @@
                 "all_favorite_friends": "좋아하는 친구들 모두",
                 "selected_favorite_groups": "선택한 즐겨찾는 그룹",
                 "selected_favorite_groups_label": "선택한 즐겨찾는 그룹",
+                "automatic_replies_note": "VRChat 실행 중이고 현재 위치에서 초대를 보낼 수 있을 때만 동작합니다. 발신자별로 쿨다운이 있습니다.",
                 "failed_to_load_schedule_rules": "일정 규칙을 로드하지 못했습니다.",
                 "failed_to_save_schedule_rules": "일정 규칙을 저장하지 못했습니다.",
                 "failed_to_load_room_rules": "인스턴스 규칙을 불러오지 못했습니다.",
                 "failed_to_save_room_rules": "인스턴스 규칙을 저장하지 못했습니다.",
                 "failed_to_load_invite_settings": "초대 요청 자동 응답 설정을 로드하지 못했습니다.",
-                "failed_to_save_invite_settings": "초대 요청 자동 응답 설정을 저장하지 못했습니다.",
-                "status_schedule_description": "상태 변경을 예약합니다. VRChat 실행 중에만 동작하도록 제한할 수 있습니다.",
-                "room_status_rules_description": "인스턴스, 월드, 친구에 따라 상태를 자동 변경합니다.",
-                "invite_request_auto_reply_description": "VRChat 실행 중 참여를 요청하는 승인된 친구를 자동으로 초대합니다.",
-                "only_when_game_running_description": "VRChat이 실행되고 있지 않으면 이 규칙을 건너뜁니다.",
-                "automatic_replies_note": "VRChat 실행 중이고 현재 위치에서 초대를 보낼 수 있을 때만 동작합니다. 발신자별로 쿨다운이 있습니다."
+                "failed_to_save_invite_settings": "초대 요청 자동 응답 설정을 저장하지 못했습니다."
             },
             "other": {
                 "header": "기타",
@@ -2033,15 +2059,15 @@
             },
             "label": {
                 "inventory_bundle_consumed": "인벤토리 번들이 소모됨",
+                "fps": "fps",
                 "frames": "프레임",
-                "prev": "이전",
-                "fps": "fps"
+                "prev": "이전"
             },
             "action": {
                 "preview": "미리보기",
+                "refresh_this_tab_to_load_your_vrchat_prints": "VRChat 프린트을 로드하려면 이 탭을 새로고침하세요.",
                 "refresh_this_tab_to_load_inventory_items": "인벤토리 항목을 로드하려면 이 탭을 새로고침하세요.",
-                "load_a_screenshot_to_inspect_embedded_world_player_and_file_metadata": "스크린샷을 로드하여 내장된 월드, 플레이어 및 파일 메타데이터를 검사하세요.",
-                "refresh_this_tab_to_load_your_vrchat_prints": "VRChat 프린트을 로드하려면 이 탭을 새로고침하세요."
+                "load_a_screenshot_to_inspect_embedded_world_player_and_file_metadata": "스크린샷을 로드하여 내장된 월드, 플레이어 및 파일 메타데이터를 검사하세요."
             },
             "error": {
                 "dropped_screenshot_path_is_not_available": "삭제된 스크린샷 경로를 사용할 수 없습니다."
@@ -2059,6 +2085,7 @@
                 "browse_for_a_screenshot_load_the_latest_screenshot_or_run_a_metadata_search": "여기에 스크린샷을 드래그 앤 드롭하거나 메타데이터 검색을 실행하세요."
             },
             "toast": {
+                "failed_to_load_value": "{value}을(를) 로드하지 못했습니다.",
                 "failed_to_load_prints": "프린트을 로드하지 못했습니다.",
                 "failed_to_load_inventory": "인벤토리를 로드하지 못했습니다.",
                 "failed_to_delete_media_item": "미디어 항목을 삭제하지 못했습니다.",
@@ -2070,17 +2097,11 @@
                 "failed_to_copy_image": "이미지를 복사하지 못했습니다.",
                 "failed_to_pin_tool_to_navigation": "도구를 탐색에 고정하지 못했습니다.",
                 "failed_to_unpin_tool_from_navigation": "탐색에서 도구를 고정 해제하지 못했습니다.",
-                "failed_to_load_value": "{value}을(를) 로드하지 못했습니다.",
                 "failed_to_update_print_favorite": "프린트 즐겨찾기를 업데이트하지 못했습니다."
             },
             "modal": {
-                "delete_print": "프린트 삭제",
-                "delete_value_item": "{value} 항목 삭제"
-            },
-            "user": {
-                "discord_names_description": "VRChat 친구의 Discord 사용자 이름 찾기",
-                "export_friend_list_description": "VRChat에서 친구 목록 내보내기",
-                "export_own_avatars_description": "VRChat에서 개인 아바타 내보내기"
+                "delete_value_item": "{value} 항목 삭제",
+                "delete_print": "프린트 삭제"
             },
             "dynamic": {
                 "no_value_loaded": "{value}이(가) 로드되지 않았습니다.",
@@ -2173,6 +2194,7 @@
         },
         "settings": {
             "header": "설정",
+            "subtitle": "환경설정, 진단 및 앱 옵션",
             "category": {
                 "notifications": "알림",
                 "advanced": "고급",
@@ -2242,6 +2264,25 @@
                 },
                 "wrist_overlay": {
                     "header": "손목 오버레이",
+                    "wrist_feed_overlay": "손목 피드 오버레이",
+                    "start_when": "시작 조건",
+                    "start_when_steamvr": "SteamVR 시작 시",
+                    "start_when_vrchat_vr_mode": "VRChat 시작 시",
+                    "overlay_button": "오버레이 버튼",
+                    "overlay_button_grip": "그립",
+                    "overlay_button_menu": "메뉴",
+                    "display_on": "표시 위치",
+                    "display_on_left": "왼쪽",
+                    "display_on_right": "오른쪽",
+                    "display_on_both": "양쪽",
+                    "size": "크기",
+                    "size_compact": "콤팩트",
+                    "size_normal": "보통",
+                    "size_large": "크게",
+                    "dark_background": "어두운 배경",
+                    "hide_private_worlds": "비공개 월드 숨기기",
+                    "vr_device_status": "VR 기기 상태",
+                    "battery_percentage": "배터리 잔량",
                     "wrist_feed_notifications": "손목 오버레이 알림 필터"
                 },
                 "test_mode": {
@@ -2342,6 +2383,10 @@
                     "refresh": "데이터베이스 상태 새로 고침",
                     "refresh_sqlite_tables": "테이블 크기 새로 고침",
                     "migrate_legacy_vrcx": "기존 VRCX 데이터 마이그레이션"
+                },
+                "danger": {
+                    "header": "위험 구역",
+                    "cannot_be_undone": "이 작업은 되돌릴 수 없습니다."
                 }
             },
             "general": {
@@ -2349,6 +2394,7 @@
                     "header": "애플리케이션",
                     "startup": "Windows 시작 시 실행",
                     "startup_system": "시스템 시작 시 시작",
+                    "startup_system_description": "--autostart를 사용하여 VRCX-0을 시작하는 데스크톱 자동 시작 항목을 만듭니다.",
                     "minimized": "최소화 상태로 시작",
                     "tray": "닫지 않고 트레이로 최소화하기",
                     "tray_description": "종료하지 않고 시스템 트레이로 최소화합니다.",
@@ -2366,8 +2412,7 @@
                     "check_for_updates_and_update": "업데이트 확인 및 설치",
                     "update_check_disabled": "비활성화됨",
                     "update_check_disabled_build_description": "이 특별 빌드에서는 업데이트 확인이 비활성화되어 있습니다. 패키지 관리자를 사용하거나 유지관리 담당자에게 문의하여 VRCX-0을 업데이트하세요.",
-                    "proxy": "프록시 설정",
-                    "startup_system_description": "--autostart를 사용하여 VRCX-0을 시작하는 데스크톱 자동 시작 항목을 만듭니다."
+                    "proxy": "프록시 설정"
                 },
                 "favorites": {
                     "header": "즐겨찾는 그룹 필터",
@@ -2398,40 +2443,8 @@
                     "font_family_description": "프리셋을 선택하거나 이 기기에 설치된 글꼴을 사용하세요.",
                     "font_family_custom": "사용자 지정 글꼴…",
                     "font_family_custom_dialog_title": "사용자 지정 글꼴 선택",
-                    "font_family_custom_invalid": "잘못된 글꼴 모음입니다. 쉼표로 구분된 글꼴 이름을 사용하세요. '내 글꼴', Arial, 산세리프체",
-                    "theme_mode_system": "시스템",
-                    "theme_mode_light": "라이트",
-                    "theme_mode_dark": "다크",
-                    "theme_mode_blue": "블루",
-                    "theme_mode_darkblue": "진한 파란색",
-                    "theme_mode_amoled": "아몰레드",
-                    "theme_mode_darkvanillaold": "다크 바닐라(구형)",
-                    "theme_mode_darkvanilla": "다크 바닐라",
-                    "theme_mode_pink": "핑크",
-                    "theme_mode_material3": "머티리얼 3",
-                    "zoom": "줌",
-                    "vrcplus_profile_icons": "프로필 아이콘으로 표시",
-                    "age_gated_instances": "연령 제한 인스턴스 표시",
-                    "age_gated_instances_description": "연령 제한 인스턴스를 표시합니다. 비활성화되면 이러한 인스턴스는 숨겨지고 제한된 것으로 표시됩니다.",
-                    "nicknames": "친구 로컬 메모 닉네임",
-                    "nicknames_description": "사용자 이름 뒤에 맞춤 로컬 메모 이름을 표시하세요.",
-                    "table_page_sizes": "테이블 페이지 크기",
-                    "table_page_sizes_description": "테이블 컨트롤에 표시된 페이지 크기 옵션을 추가, 제거 및 선택합니다.",
-                    "table_page_sizes_error": "페이지 크기는 1에서 1000 사이의 숫자여야 합니다.",
-                    "show_notification_icon_dot": "트레이 알림 점",
-                    "show_taskbar_icon_dot": "작업 표시줄 알림 점",
-                    "show_taskbar_icon_dot_description": "읽지 않은 알림이 있으면 작업 표시줄의 VRCX-0 버튼에 빨간 점을 표시합니다.",
-                    "striped_data_table_mode": "스트라이프 테이블",
-                    "reduced_motion_and_blur": "효과 줄이기",
-                    "reduced_motion_and_blur_description": "애니메이션, 전환, 배경 흐림 효과를 꺼서 저사양 기기의 성능을 개선합니다.",
-                    "accessible_status_indicators": "접근 가능한 상태 표시기",
-                    "accessible_status_indicators_description": "상태를 구분하려면 색상 외에 모양을 사용하세요.",
-                    "table_density": "테이블 밀도",
-                    "table_density_standard": "표준",
-                    "table_density_compact": "콤팩트",
-                    "table_entries_settings": "테이블 항목 설정",
-                    "table_entries_settings_description": "목록 및 검색을 위해 로드되는 항목 수를 제어합니다.",
                     "font_family_custom_dialog_description": "이 기기에 설치된 글꼴을 사용하거나 CSS 글꼴 스택을 입력하세요.",
+                    "font_family_custom_invalid": "잘못된 글꼴 모음입니다. 쉼표로 구분된 글꼴 이름을 사용하세요. '내 글꼴', Arial, 산세리프체",
                     "font_family_custom_primary": "앱 글꼴",
                     "font_family_custom_primary_description": "앱 전체에서 사용됩니다.",
                     "font_family_custom_secondary": "대체 글꼴(선택 사항)",
@@ -2453,8 +2466,40 @@
                     "font_family_custom_override_hint": "예: 'My Font', Arial, sans-serif",
                     "font_family_custom_override_active": "고급 재정의가 활성화되어 위에서 선택한 글꼴이 무시됩니다.",
                     "font_family_custom_override_placeholder": "'My Font', Arial, sans-serif",
+                    "theme_mode_system": "시스템",
+                    "theme_mode_light": "라이트",
+                    "theme_mode_dark": "다크",
+                    "theme_mode_blue": "블루",
+                    "theme_mode_darkblue": "진한 파란색",
+                    "theme_mode_amoled": "아몰레드",
+                    "theme_mode_darkvanillaold": "다크 바닐라(구형)",
+                    "theme_mode_darkvanilla": "다크 바닐라",
+                    "theme_mode_pink": "핑크",
+                    "theme_mode_material3": "머티리얼 3",
+                    "zoom": "줌",
+                    "vrcplus_profile_icons": "프로필 아이콘으로 표시",
                     "vrcplus_profile_icons_description": "프로필 아이콘이 있으면 사용자 이미지로 우선 표시합니다.",
-                    "show_instance_id": "인스턴스 ID 표시"
+                    "show_instance_id": "인스턴스 ID 표시",
+                    "age_gated_instances": "연령 제한 인스턴스 표시",
+                    "age_gated_instances_description": "연령 제한 인스턴스를 표시합니다. 비활성화되면 이러한 인스턴스는 숨겨지고 제한된 것으로 표시됩니다.",
+                    "nicknames": "친구 로컬 메모 닉네임",
+                    "nicknames_description": "사용자 이름 뒤에 맞춤 로컬 메모 이름을 표시하세요.",
+                    "table_page_sizes": "테이블 페이지 크기",
+                    "table_page_sizes_description": "테이블 컨트롤에 표시된 페이지 크기 옵션을 추가, 제거 및 선택합니다.",
+                    "table_page_sizes_error": "페이지 크기는 1에서 1000 사이의 숫자여야 합니다.",
+                    "show_notification_icon_dot": "트레이 알림 점",
+                    "show_taskbar_icon_dot": "작업 표시줄 알림 점",
+                    "show_taskbar_icon_dot_description": "읽지 않은 알림이 있으면 작업 표시줄의 VRCX-0 버튼에 빨간 점을 표시합니다.",
+                    "striped_data_table_mode": "스트라이프 테이블",
+                    "reduced_motion_and_blur": "효과 줄이기",
+                    "reduced_motion_and_blur_description": "애니메이션, 전환, 배경 흐림 효과를 꺼서 저사양 기기의 성능을 개선합니다.",
+                    "accessible_status_indicators": "접근 가능한 상태 표시기",
+                    "accessible_status_indicators_description": "상태를 구분하려면 색상 외에 모양을 사용하세요.",
+                    "table_density": "테이블 밀도",
+                    "table_density_standard": "표준",
+                    "table_density_compact": "콤팩트",
+                    "table_entries_settings": "테이블 항목 설정",
+                    "table_entries_settings_description": "목록 및 검색을 위해 로드되는 항목 수를 제어합니다."
                 },
                 "display": {
                     "header": "디스플레이"
@@ -2506,16 +2551,17 @@
                     "nameplate_effect": "네임플레이트 효과 표시",
                     "nameplate_effect_description": "표시 이름 뒤에 적용된 네임플레이트 효과를 표시합니다.",
                     "additional_information": "기타 정보",
-                    "vrcx_memos": "로컬 메모",
-                    "recent_action_cooldown": "최근 작업 아이콘",
-                    "recent_action_cooldown_description": "최근 초대 및 요청 작업에 시계 아이콘을 표시합니다.",
                     "vrchat_notes": "VRChat 메모",
                     "vrchat_notes_description": "VRChat에 저장된 메모를 표시합니다.",
-                    "vrcx_memos_description": "VRCX-0에 저장된 로컬 메모를 표시합니다."
+                    "vrcx_memos": "로컬 메모",
+                    "vrcx_memos_description": "VRCX-0에 저장된 로컬 메모를 표시합니다.",
+                    "recent_action_cooldown": "최근 작업 아이콘",
+                    "recent_action_cooldown_description": "최근 초대 및 요청 작업에 시계 아이콘을 표시합니다."
                 },
                 "user_colors": {
                     "header": "유저 색상",
                     "random_colors_from_user_id": "유저 ID별 무작위 색상 사용",
+                    "random_colors_from_user_id_description": "ID를 기반으로 각 사용자에게 일관된 색상을 할당합니다.",
                     "trust_colors": "신뢰 수준 색상",
                     "trust_colors_description": "신뢰 수준 이름에 사용되는 색상을 사용자 정의합니다.",
                     "trust_levels": {
@@ -2524,10 +2570,9 @@
                         "user": "사용자",
                         "known_user": "알려진 사용자",
                         "trusted_user": "신뢰할 수 있는 사용자",
-                        "nuisance": "귀찮은 사용자",
-                        "vrchat_team": "VRChat 팀"
-                    },
-                    "random_colors_from_user_id_description": "ID를 기반으로 각 사용자에게 일관된 색상을 할당합니다."
+                        "vrchat_team": "VRChat 팀",
+                        "nuisance": "귀찮은 사용자"
+                    }
                 },
                 "friend_log": {
                     "header": "친구 이력",
@@ -2541,6 +2586,8 @@
                     "layout": "알림 보기",
                     "layout_notification_center": "알림 센터",
                     "layout_table": "알림 페이지",
+                    "post_update_changelog_prompt": "업데이트 후 변경 사항 표시",
+                    "post_update_changelog_prompt_description": "업데이트 설치 후 새로운 기능을 보여줍니다.",
                     "do_not_disturb": {
                         "header": "방해 금지",
                         "description": "데스크톱 알림, TTS, XSOverlay, OVR Toolkit 및 VRCX-0 HMD 팝업을 일시 중지합니다. Webhook, 손목 활동 및 알림 기록은 계속됩니다.",
@@ -2562,9 +2609,9 @@
                         "desktop": "데스크톱 모드",
                         "inside_vr": "VR을 쓰고 있을 때",
                         "outside_vr": "VR을 벗고 있을 때",
-                        "always": "항상",
                         "inside_vrchat": "VRChat에서",
-                        "outside_vrchat": "VRChat 외부"
+                        "outside_vrchat": "VRChat 외부",
+                        "always": "항상"
                     },
                     "desktop_notifications": {
                         "header": "데스크톱 알림",
@@ -2731,6 +2778,7 @@
                 },
                 "advanced": {
                     "launch_options": "VRChat 실행 설정",
+                    "vrc_registry_backup": "VRChat 레지스트리 백업",
                     "relaunch_vrchat": {
                         "header": "VRChat이 터지면 재시작",
                         "description": "VRChat이 터질경우 직전 인스턴스로 재입장합니다"
@@ -2752,9 +2800,9 @@
                     },
                     "save_instance_prints_to_file": {
                         "header": "인스턴스 프린트를 파일에 저장",
-                        "crop": "프린트에서 흰색 테두리 자동 제거",
                         "header_tooltip": "--enable-sdk-log-levels VRChat 시작 옵션이 필요합니다.",
-                        "description": "생성된 프린트을 VRChat Pictures 폴더에 저장하세요."
+                        "description": "생성된 프린트을 VRChat Pictures 폴더에 저장하세요.",
+                        "crop": "프린트에서 흰색 테두리 자동 제거"
                     },
                     "save_instance_stickers_to_file": {
                         "header": "인스턴스 스티커를 파일에 저장",
@@ -2766,10 +2814,10 @@
                     },
                     "delete_all_screenshot_metadata": {
                         "button": "스크린샷 메타데이터 제거",
-                        "confirm_yes": "예",
-                        "confirm_no": "아니요",
                         "ask": "VRChat Pictures 폴더에서 모든 VRChat 및 VRCX-0 스크린샷 메타데이터를 삭제하시겠습니까?",
-                        "confirm": "모든 스크린샷 메타데이터가 영구적으로 삭제되며 되돌릴 수 없습니다. VRChat Pictures 폴더의 모든 프린트, 하위 폴더 및 기타 파일이 포함됩니다. 중요한 사진은 진행하기 전에 백업해 두세요."
+                        "confirm": "모든 스크린샷 메타데이터가 영구적으로 삭제되며 되돌릴 수 없습니다. VRChat Pictures 폴더의 모든 프린트, 하위 폴더 및 기타 파일이 포함됩니다. 중요한 사진은 진행하기 전에 백업해 두세요.",
+                        "confirm_yes": "예",
+                        "confirm_no": "아니요"
                     },
                     "remote_database": {
                         "header": "원격 아바타 데이터베이스",
@@ -2786,8 +2834,8 @@
                     "translation_api": {
                         "header": "콘텐츠 번역",
                         "enable": "활성화",
-                        "enable_tooltip": "필요에 따라 사용자 약력과 세계 설명을 번역합니다.",
-                        "translation_api_key": "제공업체 설정"
+                        "translation_api_key": "제공업체 설정",
+                        "enable_tooltip": "필요에 따라 사용자 약력과 세계 설명을 번역합니다."
                     },
                     "screenshot_helper": {
                         "header": "스크린샷 도우미",
@@ -2800,20 +2848,20 @@
                     },
                     "data_directory": {
                         "header": "데이터 디렉토리",
+                        "description": "현재 사용 중: {source}",
                         "current": "현재 디렉토리",
                         "actions": "데이터 디렉터리 작업",
                         "choose": "폴더 선택",
                         "reset": "기본값으로 재설정",
                         "restart": "다시 시작",
+                        "restart_hint": "VRCX-0을(를) 다시 시작한 후에 변경 사항이 적용됩니다.",
                         "source_cli": "명령줄 재정의",
                         "source_persisted": "직접 지정한 폴더",
                         "source_default": "기본 폴더",
                         "cli_override": "이번 실행에서는 --data-dir을 사용하고 있습니다. 저장된 디렉터리를 변경하려면 명령줄 재정의 없이 시작하세요.",
-                        "failed_to_load": "데이터 디렉터리 설정을 로드하지 못했습니다.",
-                        "description": "현재 사용 중: {source}",
-                        "restart_hint": "VRCX-0을(를) 다시 시작한 후에 변경 사항이 적용됩니다.",
                         "saved_restart_required": "데이터 디렉터리가 저장되었습니다. 적용하려면 VRCX-0을(를) 다시 시작하세요.",
-                        "reset_saved": "데이터 디렉토리 재설정. 적용하려면 VRCX-0을(를) 다시 시작하세요."
+                        "reset_saved": "데이터 디렉토리 재설정. 적용하려면 VRCX-0을(를) 다시 시작하세요.",
+                        "failed_to_load": "데이터 디렉터리 설정을 로드하지 못했습니다."
                     },
                     "cache_debug": {
                         "header": "VRCX-0 인스턴스 캐시/디버그",
@@ -2828,6 +2876,7 @@
                         "instance_cache": "인스턴스 캐시:"
                     },
                     "sqlite_table_size": {
+                        "gps": "GPS:",
                         "status": "상태:",
                         "bio": "약력:",
                         "avatar": "아바타:",
@@ -2838,8 +2887,7 @@
                         "join_leave": "가입/탈퇴:",
                         "portal_spawn": "포털 생성:",
                         "video_play": "비디오 재생:",
-                        "event": "이벤트:",
-                        "gps": "GPS:"
+                        "event": "이벤트:"
                     },
                     "database_cleanup": {
                         "auto_cleanup": "다음보다 오래된 자동 정리 아바타 데이터",
@@ -2858,17 +2906,17 @@
                         "purge_confirm_title": "아바타 피드 데이터 삭제",
                         "purge_confirm_description_1": "이렇게 하면 데이터베이스에서 아바타 변경 기록이 영구적으로 삭제되고 디스크 공간이 회수됩니다.",
                         "purge_confirm_description_2": "이 작업은 취소할 수 없습니다!",
+                        "purge_confirm_description_3": "VRCX-0은 작업이 완료된 후 다시 시작됩니다.",
                         "purge_confirm_alert": "계속하기 전에 데이터베이스 파일을 백업하는 것이 좋습니다!",
                         "purge_confirm_button": "퍼지 및 재시작",
                         "purge_complete": "아바타 데이터가 성공적으로 삭제되었습니다. 다시 시작하는 중",
-                        "legacy_migration_confirm": "마이그레이션 및 다시 시작",
-                        "purge_confirm_description_3": "VRCX-0은 작업이 완료된 후 다시 시작됩니다.",
                         "purge_failed": "제거 실패: {error}",
                         "purge_optimization_failed": "아바타 데이터는 삭제했지만 데이터베이스를 최적화하지 못했습니다: {error}",
                         "legacy_migration": "VRCX 데이터 마이그레이션",
                         "legacy_migration_description": "현재 VRCX-0 구성 및 데이터베이스를 고정 VRCX 데이터 폴더의 데이터로 바꿉니다.",
                         "legacy_migration_confirm_title": "VRCX-0 데이터를 VRCX 데이터로 바꾸시겠습니까?",
                         "legacy_migration_confirm_description": "그러면 현재 VRCX-0 설정과 로컬 데이터베이스가 삭제되고 {path}에 있는 데이터로 대체됩니다. VRCX-0이(가) 다시 시작되어 마이그레이션을 완료합니다. 원본 VRCX 데이터는 수정되지 않습니다.",
+                        "legacy_migration_confirm": "마이그레이션 및 다시 시작",
                         "legacy_migration_not_available": "지원되는 VRCX 데이터베이스를 찾을 수 없습니다.",
                         "legacy_migration_restart_manually": "마이그레이션이 준비되었습니다. 완료하려면 VRCX-0을(를) 다시 시작하세요.",
                         "legacy_migration_failed": "VRCX 마이그레이션을 시작하지 못했습니다: {error}"
@@ -2876,11 +2924,10 @@
                     "user_content": {
                         "header": "콘텐츠 폴더",
                         "folder": "폴더 열기",
+                        "description": "프린트, 스티커 등 VRChat 콘텐츠에 대한 폴더를 열거나 설정하세요.",
                         "set_folder": "폴더 설정",
-                        "reset_override": "재설정",
-                        "description": "프린트, 스티커 등 VRChat 콘텐츠에 대한 폴더를 열거나 설정하세요."
+                        "reset_override": "재설정"
                     },
-                    "vrc_registry_backup": "VRChat 레지스트리 백업",
                     "auto_delete_prints": {
                         "enable": "오래된 VRChat 프린트 자동 삭제",
                         "description": "프린트 목록이 제한을 초과하면 즐겨찾기가 아닌 가장 오래된 프린트을 삭제합니다.",
@@ -2907,13 +2954,13 @@
                 "failed_to_load_settings": "설정을 로드하지 못했습니다.",
                 "failed_to_save_trust_color": "신뢰 색상을 저장하지 못했습니다.",
                 "failed_to_refresh_sqlite_table_sizes": "SQLite 테이블 크기를 새로 고치지 못했습니다.",
+                "failed_to_refresh_config_json": "JSON 구성을 새로 고치지 못했습니다.",
                 "failed_to_refresh_online_user_count": "온라인 사용자 수를 새로 고치지 못했습니다.",
                 "failed_to_save_proxy_settings": "프록시 설정을 저장하지 못했습니다.",
                 "failed_to_crop_existing_prints": "기존 프린트을 자르지 못했습니다.",
                 "failed_to_save_translation_settings": "번역 설정을 저장하지 못했습니다.",
                 "failed_to_fetch_translation_models": "번역 모델을 가져오지 못했습니다.",
-                "failed_to_save_feed_filters": "피드 필터를 저장하지 못했습니다.",
-                "failed_to_refresh_config_json": "JSON 구성을 새로 고치지 못했습니다."
+                "failed_to_save_feed_filters": "피드 필터를 저장하지 못했습니다."
             },
             "modal": {
                 "crop_existing_prints": "기존 프린트 자르기",
@@ -3021,10 +3068,10 @@
                 "no_current_instance_detected": "현재 인스턴스가 감지되지 않았습니다.",
                 "no_players_reconstructed_for_this_instance_yet": "현재 플레이어를 아직 찾지 못했습니다.",
                 "enable_game_log_ingestion_in_settings_before_current_players_can_be_reconstructed": "현재 플레이어를 보려면 설정에서 게임 로그를 활성화하세요.",
+                "start_vrchat_and_let_vrcx_receive_game_log_events_before_this_page_can_rebuild_the_current_instance": "VRChat을 실행하고 인스턴스에 입장하면 같은 곳에 있는 플레이어가 여기에 표시됩니다. 누군가 들어오거나 나가면 목록도 자동으로 업데이트됩니다.",
                 "stay_in_the_instance_until_local_join_leave_events_are_recorded": "VRCX-0이 플레이어 활동을 감지할 때까지 인스턴스에 머무르세요. 이 목록은 자동으로 업데이트됩니다.",
                 "current_players_follow_live_instance_locations": "VRCX-0이 다음 위치를 감지하면 현재 플레이어가 표시됩니다.",
-                "local_join_leave_history_has_no_current_players": "로컬 가입/탈퇴 기록에는 아직 활성 위치에 대한 현재 플레이어가 없습니다.",
-                "start_vrchat_and_let_vrcx_receive_game_log_events_before_this_page_can_rebuild_the_current_instance": "VRChat을 실행하고 인스턴스에 입장하면 같은 곳에 있는 플레이어가 여기에 표시됩니다. 누군가 들어오거나 나가면 목록도 자동으로 업데이트됩니다."
+                "local_join_leave_history_has_no_current_players": "로컬 가입/탈퇴 기록에는 아직 활성 위치에 대한 현재 플레이어가 없습니다."
             },
             "label": {
                 "instance_master": "인스턴스 마스터",
@@ -3053,6 +3100,12 @@
         "auth": {
             "auto_login": {
                 "skipped": "자동 로그인을 건너뛰었습니다.",
+                "preparing_login_for": "{name}에 대한 자동 로그인 준비 중",
+                "preparing_restore_for": "{userId}에 대한 자동 세션 복원 준비 중",
+                "authenticating": "{name} 인증 중",
+                "restoring_session_for": "{name}에 대한 기존 브라우저 세션 복원 중",
+                "logged_in_as": "{name}(으)로 자동 로그인되었습니다.",
+                "restored_session_for": "{name}에 대한 이전 브라우저 세션을 자동으로 복원했습니다.",
                 "skipped_before_request": "자동 로그인이 시작되기 전에 취소되었습니다.",
                 "throttled": "지난 한 시간 동안 반복된 실패로 인해 자동 로그인이 비활성화되었습니다.",
                 "expired": "이전 브라우저 세션이 만료되었으며 저장된 계정 대체를 사용할 수 없습니다.",
@@ -3062,13 +3115,7 @@
                 "skipped_manual_started": "수동 로그인이 시작되었기 때문에 자동 로그인을 건너뛰었습니다.",
                 "skipped_saved_account_selected": "저장된 다른 계정을 선택했기 때문에 자동 로그인을 건너뛰었습니다.",
                 "skipped_countdown_finished": "카운트다운이 완료되기 전에 자동 로그인을 건너뛰었습니다.",
-                "skipped_saved_account_edited": "저장된 계정을 편집 중이므로 자동 로그인을 건너뛰었습니다.",
-                "preparing_login_for": "{name}에 대한 자동 로그인 준비 중",
-                "preparing_restore_for": "{userId}에 대한 자동 세션 복원 준비 중",
-                "authenticating": "{name} 인증 중",
-                "restoring_session_for": "{name}에 대한 기존 브라우저 세션 복원 중",
-                "logged_in_as": "{name}(으)로 자동 로그인되었습니다.",
-                "restored_session_for": "{name}에 대한 이전 브라우저 세션을 자동으로 복원했습니다."
+                "skipped_saved_account_edited": "저장된 계정을 편집 중이므로 자동 로그인을 건너뛰었습니다."
             },
             "toast": {
                 "failed_to_load_saved_auth_snapshot": "저장된 계정을 불러오지 못했습니다.",
@@ -3095,6 +3142,7 @@
                 "failed_to_copy_favorite_export_data": "즐겨찾는 내보내기 데이터를 복사하지 못했습니다.",
                 "failed_to_refresh_favorites": "즐겨찾기를 새로고침하지 못했습니다.",
                 "failed_to_remove_local_favorite": "로컬 즐겨찾기를 삭제하지 못했습니다.",
+                "failed_to_remove_vrchat_favorite": "VRChat 즐겨찾기를 제거하지 못했습니다.",
                 "failed_to_rename_favorite_group": "즐겨찾는 그룹의 이름을 바꾸지 못했습니다.",
                 "failed_to_change_group_visibility": "그룹 공개 상태를 변경하지 못했습니다.",
                 "failed_to_clear_favorite_group": "즐겨찾는 그룹을 삭제하지 못했습니다.",
@@ -3111,11 +3159,11 @@
                 "failed_to_create_local_favorite_group": "로컬 즐겨찾기 그룹을 생성하지 못했습니다.",
                 "failed_to_copy_selected_favorites": "선택한 즐겨찾기를 복사하지 못했습니다.",
                 "failed_to_move_selected_favorites": "선택한 즐겨찾기를 이동하지 못했습니다.",
-                "failed_to_remove_vrchat_favorite": "VRChat 즐겨찾기를 제거하지 못했습니다.",
                 "favorites_refresh_unavailable": "로그인된 계정이 없어 즐겨찾기를 새로고침할 수 없습니다"
             },
             "modal": {
                 "remove_local_favorite": "로컬 즐겨찾기를 삭제하시겠습니까?",
+                "remove_vrchat_favorite": "VRChat 즐겨찾기를 삭제하시겠습니까?",
                 "change_favorite_group_name": "즐겨찾는 그룹 이름 변경",
                 "enter_the_new_display_name": "새 표시 이름을 입력하세요.",
                 "change": "변경",
@@ -3124,17 +3172,16 @@
                 "rename_local_favorite_group": "로컬 즐겨찾는 그룹 이름 바꾸기",
                 "enter_the_new_local_group_name": "새 로컬 그룹 이름을 입력하세요.",
                 "delete_local_favorite_group": "로컬 즐겨찾는 그룹을 삭제하시겠습니까?",
+                "delete_value": "{value}을(를) 삭제하시겠습니까?",
                 "clear_avatar_history": "아바타 기록을 삭제하시겠습니까?",
                 "send_invite": "초대장을 보내시겠습니까?",
                 "invite": "초대",
                 "request_invite": "초대를 요청하시겠습니까?",
                 "request_invite_2": "초대 요청",
                 "send": "보내기",
+                "delete_value_favorites": "{value} 즐겨찾기를 삭제하시겠습니까?",
                 "this_action_cannot_be_undone": "이 작업은 취소할 수 없습니다.",
-                "clear_local_avatar_history": "로컬 아바타 기록을 삭제하시겠습니까?",
-                "remove_vrchat_favorite": "VRChat 즐겨찾기를 삭제하시겠습니까?",
-                "delete_value": "{value}을(를) 삭제하시겠습니까?",
-                "delete_value_favorites": "{value} 즐겨찾기를 삭제하시겠습니까?"
+                "clear_local_avatar_history": "로컬 아바타 기록을 삭제하시겠습니까?"
             },
             "empty": {
                 "favorite_fallback": "좋아하는",
@@ -3173,12 +3220,12 @@
         },
         "friends": {
             "toast": {
+                "failed_to_unfriend_value": "{value} 친구를 끊지 못했습니다.",
                 "failed_to_launch_instance": "인스턴스를 시작하지 못했습니다.",
                 "failed_to_send_self_invite": "본인 초대를 보내지 못했습니다.",
                 "failed_to_send_invite": "초대장을 보내지 못했습니다.",
                 "failed_to_request_invite": "초대를 요청하지 못했습니다.",
-                "failed_to_send_boop": "부프를 보내지 못했습니다.",
-                "failed_to_unfriend_value": "{value} 친구를 끊지 못했습니다."
+                "failed_to_send_boop": "부프를 보내지 못했습니다."
             },
             "modal": {
                 "unfriend_user": "사용자를 친구 해제하시겠습니까?",
@@ -3210,11 +3257,11 @@
             },
             "modal": {
                 "delete_notification_log_entry": "알림을 삭제할까요?",
+                "delete_the_local_value_log_entry": "이 {value} 알림을 기록에서 삭제할까요?",
                 "accept_friend_request": "친구 요청 수락",
                 "decline_notification": "알림 거부",
                 "decline": "거절",
-                "send_invite": "초대장 보내기",
-                "delete_the_local_value_log_entry": "이 {value} 알림을 기록에서 삭제할까요?"
+                "send_invite": "초대장 보내기"
             },
             "dynamic": {
                 "accept_the_friend_request_from_value": "{value}의 친구 요청을 수락하시겠습니까?",
@@ -3250,9 +3297,9 @@
                 "disable_theme": "테마 비활성화",
                 "delete_theme": "테마 삭제",
                 "apply_override": "재정의 적용",
+                "disable_override": "맞춤 CSS 비활성화",
                 "clear_override": "재정의 지우기",
                 "contribute": "테마 생성 및 제출",
-                "disable_override": "맞춤 CSS 비활성화",
                 "contribute_tooltip": "GitHub에서 테마 제작 및 제출 지침을 확인하세요."
             },
             "browse": {
@@ -3262,6 +3309,9 @@
                 "header": "설치된 테마",
                 "empty": "아직 커뮤니티 테마가 설치되어 있지 않습니다.",
                 "accent_controlled": "이 커뮤니티 테마는 강조 색상을 제어하므로 내장된 강조 선택기가 비활성화됩니다."
+            },
+            "override": {
+                "placeholder": ":root {\n  --vrcx-0-main-content-surface: transparent;\n}"
             },
             "developer": {
                 "header": "로컬 테마 미리보기",
@@ -3283,21 +3333,18 @@
                 "theme_disabled": "커뮤니티 테마가 비활성화되었습니다.",
                 "theme_deleted": "설치된 테마가 삭제되었습니다.",
                 "theme_failed": "커뮤니티 테마를 활성화하지 못했습니다.",
-                "disable_failed": "커뮤니티 테마 설정을 업데이트하지 못했습니다.",
                 "override_saved": "CSS 재정의가 적용되었습니다.",
                 "override_disabled": "사용자 정의 CSS이 비활성화되었습니다.",
-                "override_cleared": "CSS 재정의가 삭제되었습니다."
-            },
-            "override": {
-                "placeholder": ":root {\n  --vrcx-0-main-content-surface: transparent;\n}"
+                "override_cleared": "CSS 재정의가 삭제되었습니다.",
+                "disable_failed": "커뮤니티 테마 설정을 업데이트하지 못했습니다."
             }
         },
         "themes": {
             "header": "테마",
             "settings": {
                 "header": "테마",
-                "current_source": "현재 소스",
-                "description": "테마 소스, 배경 이미지, 커뮤니티 테마, 강조 색상, 사용자 정의 CSS을 관리합니다."
+                "description": "테마 소스, 배경 이미지, 커뮤니티 테마, 강조 색상, 사용자 정의 CSS을 관리합니다.",
+                "current_source": "현재 소스"
             },
             "summary": {
                 "header": "현재 테마",
@@ -3305,9 +3352,9 @@
             },
             "source": {
                 "built_in": "기본값",
+                "built_in_description": "VRCX-0의 기본 밝은 테마와 어두운 테마를 사용하세요.",
                 "background": "배경 이미지",
-                "community": "커뮤니티 테마",
-                "built_in_description": "VRCX-0의 기본 밝은 테마와 어두운 테마를 사용하세요."
+                "community": "커뮤니티 테마"
             },
             "accent": {
                 "header": "악센트 색상",
@@ -3317,14 +3364,14 @@
             "custom_css": {
                 "status_on": "켜기",
                 "status_off": "끄기",
+                "header": "맞춤 CSS",
                 "edit": "편집",
-                "hide_editor": "편집기 숨기기",
-                "header": "맞춤 CSS"
+                "hide_editor": "편집기 숨기기"
             },
             "developer": {
+                "preview_active": "{name} 미리보기 중입니다.",
                 "show": "도구 표시",
-                "hide": "도구 숨기기",
-                "preview_active": "{name} 미리보기 중입니다."
+                "hide": "도구 숨기기"
             },
             "action": {
                 "open_themes": "오픈 테마"
@@ -3343,14 +3390,14 @@
                 "apod_note": "NASA APOD는 저작권 필드가 없는 이미지만 사용합니다.",
                 "folder_recursive_note": "하위 폴더의 이미지도 읽습니다.",
                 "current_image": "현재 이미지",
+                "image_count": "{count} 이미지",
                 "rotation": "회전",
                 "no_image": "로드된 이미지가 없습니다.",
                 "no_image_description": "이미지를 로드하려면 소스를 새로 고치거나 선택하세요.",
                 "source_type_file": "로컬 파일",
                 "source_type_files": "선택한 파일",
                 "source_type_folder": "폴더",
-                "resolved_at": "로드됨",
-                "image_count": "{count} 이미지"
+                "resolved_at": "로드됨"
             },
             "mode": {
                 "daily": "일일 이미지",
@@ -3520,13 +3567,16 @@
             "scope_all": "모두",
             "scope_desktop": "데스크탑",
             "scope_vr": "VR",
+            "run_policy_always": "VRChat 시작마다",
             "run_policy_skipIfRunning": "실행 중인 경우 건너뛰기",
             "run_policy_short_always": "모든 시작",
             "run_policy_short_skipIfRunning": "실행 중 건너뛰기",
             "stop_policy_keepRunning": "계속 실행",
+            "stop_policy_closeByVrcx": "VRCX-0이 종료",
             "stop_policy_short_keepRunning": "유지",
             "stop_policy_short_closeByVrcx": "닫기",
             "delete": "삭제",
+            "steam_app_id": "Steam 앱 ID",
             "delay_seconds": "실행 지연 시간(초)",
             "args": "인수",
             "run_as_administrator": "관리자 권한으로 실행",
@@ -3547,10 +3597,7 @@
                 "save_failed": "앱 런처를 저장하지 못했습니다.",
                 "pick_failed": "앱 또는 바로가기를 선택하지 못했습니다.",
                 "name_target_required": "이름과 대상은 필수 항목입니다."
-            },
-            "run_policy_always": "VRChat 시작마다",
-            "stop_policy_closeByVrcx": "VRCX-0이 종료",
-            "steam_app_id": "Steam 앱 ID"
+            }
         },
         "user": {
             "status": {
@@ -3567,7 +3614,10 @@
             },
             "badges": {
                 "assigned": "할당됨",
-                "hidden": "숨겨진"
+                "hidden": "숨겨진",
+                "visible": "표시",
+                "visibility": "가시성",
+                "developer": "VRCX-0 개발자"
             },
             "actions": {
                 "invite": "초대",
@@ -3605,7 +3655,6 @@
                 "edit_note_memo": "메모 및 로컬 메모 편집"
             },
             "group_invite": {
-                "description": "{value}을(를) 초대할 그룹을 선택하세요.",
                 "select_group": "그룹 선택...",
                 "loading": "초대를 보낼 수 있는 그룹을 불러오는 중...",
                 "no_groups": "초대를 보낼 수 있는 그룹이 없습니다",
@@ -3659,10 +3708,12 @@
                 "bio": "자기소개",
                 "translate_bio": "약력 번역",
                 "show_original_bio": "원본 표시",
+                "open_bio_link": "{link} 열기",
                 "last_seen": "마지막으로 본 시간",
                 "join_count": "방문 횟수",
                 "time_together": "함께한 시간",
                 "play_time": "플레이 시간",
+                "estimated_online_for": "온라인 시간 약 {duration}",
                 "last_activity": "마지막 활동",
                 "date_joined": "계정 생성일",
                 "friended": "친구 추가됨",
@@ -3684,7 +3735,6 @@
                 "instance_age_restricted": "제한됨",
                 "instance_age_restricted_tooltip": "연령 제한이 있는 경우",
                 "show_mutual_friends": "상호 친구 표시",
-                "open_bio_link": "{link} 열기",
                 "show_discord_connections": "Discord 연결 표시"
             },
             "groups": {
@@ -3743,6 +3793,7 @@
             "activity": {
                 "header": "활동",
                 "refresh_hint": "활동 데이터 새로 고침",
+                "total_events": "{count} 온라인 이벤트",
                 "most_active_day": "가장 활동적인 날:",
                 "most_active_time": "피크 시간:",
                 "period": "기간:",
@@ -3782,8 +3833,7 @@
                 },
                 "preparing_data": "활동 데이터 준비 중...",
                 "preparing_data_hint": "처음 로드할 때 약간의 시간이 걸릴 수 있습니다.",
-                "failed_to_load": "활동을 로드하지 못했습니다.",
-                "total_events": "{count} 온라인 이벤트"
+                "failed_to_load": "활동을 로드하지 못했습니다."
             },
             "note_memo": {
                 "header": "메모 및 로컬 메모 편집"
@@ -3819,6 +3869,7 @@
                 "pronouns": "대명사",
                 "bio_links": "바이오 링크",
                 "bio": "바이오",
+                "vrchat_language_list_unavailable_using_local_language_codes": "VRChat 언어 목록을 사용할 수 없습니다. 현지 언어 코드를 사용합니다.",
                 "previous_display_names": "이전 표시 이름",
                 "visibility_everyone": "모든 사람",
                 "visibility_friends": "친구",
@@ -3827,7 +3878,6 @@
                 "muted": "음소거됨",
                 "order_by": "정렬 기준",
                 "group_by": "그룹화 기준",
-                "vrchat_language_list_unavailable_using_local_language_codes": "VRChat 언어 목록을 사용할 수 없습니다. 현지 언어 코드를 사용합니다.",
                 "trust_level": "신뢰 등급",
                 "age_verified": "연령 인증 완료",
                 "platform": "마지막으로 사용한 플랫폼",
@@ -3841,13 +3891,13 @@
                 "avatar_cloning_setting_updated": "아바타 복제 설정이 업데이트되었습니다.",
                 "booping_setting_updated": "부핑 설정이 업데이트되었습니다.",
                 "shared_connections_setting_updated": "공유 연결 설정이 업데이트되었습니다.",
+                "discord_connections_setting_updated": "Discord 연결 설정이 업데이트되었습니다.",
                 "report_sent": "신고가 전송되었습니다.",
                 "boop_sent": "부프를 보냈습니다",
                 "profile_details_updated": "프로필 세부정보가 업데이트되었습니다.",
                 "group_invite_sent": "그룹 초대가 전송되었습니다.",
                 "left_group": "그룹에서 나감",
-                "group_order_updated": "그룹 순서가 업데이트되었습니다.",
-                "discord_connections_setting_updated": "Discord 연결 설정이 업데이트되었습니다."
+                "group_order_updated": "그룹 순서가 업데이트되었습니다."
             },
             "empty": {
                 "friend_request_is_no_longer_active": "친구 요청이 더 이상 활성화되지 않습니다.",
@@ -3860,13 +3910,13 @@
                 "no_results": "결과 없음"
             },
             "error": {
+                "cannot_invite_no_current_vrchat_location_is_available": "초대할 수 없습니다. 현재 VRChat 위치를 사용할 수 없습니다.",
                 "cannot_invite_from_the_current_instance_type": "현재 인스턴스 유형에서는 초대할 수 없습니다.",
                 "cannot_invite_current_location_is_not_a_concrete_instance": "초대할 수 없습니다. 현재 위치는 구체적인 인스턴스가 아닙니다.",
                 "user_profile_unavailable": "사용자 프로필을 사용할 수 없습니다.",
                 "avatar_author_unavailable": "아바타 작성자를 사용할 수 없습니다.",
                 "blocked": "차단됨",
-                "cannot_load_message_templates_no_current_user_session_is_available": "메시지 템플릿을 로드할 수 없습니다. 현재 사용자 세션을 사용할 수 없습니다.",
-                "cannot_invite_no_current_vrchat_location_is_available": "초대할 수 없습니다. 현재 VRChat 위치를 사용할 수 없습니다."
+                "cannot_load_message_templates_no_current_user_session_is_available": "메시지 템플릿을 로드할 수 없습니다. 현재 사용자 세션을 사용할 수 없습니다."
             },
             "description": {
                 "update_your_social_status_and_status_description": "소셜 상태 및 상태 메시지 업데이트",
@@ -3886,6 +3936,7 @@
                 "failed_to_update_avatar_cloning_setting": "아바타 복제 설정을 업데이트하지 못했습니다.",
                 "failed_to_update_booping_setting": "부핑 설정을 업데이트하지 못했습니다.",
                 "failed_to_update_shared_connections_setting": "공유 연결 설정을 업데이트하지 못했습니다.",
+                "failed_to_update_discord_connections_setting": "Discord 연결 설정을 업데이트하지 못했습니다.",
                 "failed_to_update_badge": "배지를 업데이트하지 못했습니다.",
                 "failed_to_unfriend_user": "사용자의 친구를 해제하지 못했습니다.",
                 "applied_on_vrchat_but_local_update_failed": "VRChat에 적용했지만 로컬 업데이트에 실패했습니다.",
@@ -3893,6 +3944,9 @@
                 "friend_request_sent": "친구 요청이 전송되었습니다",
                 "friend_request_declined": "친구 요청이 거부되었습니다.",
                 "friend_request_cancelled": "친구 요청이 취소되었습니다.",
+                "value_failed": "{value} 실패",
+                "failed_to_value_user": "{value} 사용자 실패",
+                "failed_to_value": "{value}에 실패했습니다.",
                 "failed_to_update_avatar_moderation": "아바타 검토를 업데이트하지 못했습니다.",
                 "failed_to_report_user": "사용자를 신고하지 못했습니다.",
                 "invite_message_sent": "초대 메시지가 전송되었습니다.",
@@ -3902,18 +3956,14 @@
                 "failed_to_request_invite": "초대를 요청하지 못했습니다.",
                 "failed_to_send_boop": "부프를 보내지 못했습니다.",
                 "already_viewing_user": "이미 이 사용자를 보고 있습니다.",
+                "failed_to_open_discord_profile": "Discord 프로필을 열지 못했습니다.",
                 "translation_failed": "번역 실패",
                 "failed_to_load_avatar_author": "아바타 작성자를 로드하지 못했습니다.",
                 "failed_to_send_group_invite": "그룹 초대를 보내지 못했습니다.",
                 "user_already_group_member": "이 사용자는 이미 그룹 멤버입니다.",
                 "failed_to_update_group_visibility": "그룹 공개 상태를 업데이트하지 못했습니다.",
                 "failed_to_leave_group": "그룹에서 탈퇴하지 못했습니다.",
-                "failed_to_update_group_order": "그룹 순서를 업데이트하지 못했습니다.",
-                "failed_to_update_discord_connections_setting": "Discord 연결 설정을 업데이트하지 못했습니다.",
-                "value_failed": "{value} 실패",
-                "failed_to_value_user": "{value} 사용자 실패",
-                "failed_to_value": "{value}에 실패했습니다.",
-                "failed_to_open_discord_profile": "Discord 프로필을 열지 못했습니다."
+                "failed_to_update_group_order": "그룹 순서를 업데이트하지 못했습니다."
             },
             "modal": {
                 "report_hacking": "해킹을 신고하시겠습니까?",
@@ -3921,11 +3971,11 @@
                 "send_invite": "초대장을 보내시겠습니까?",
                 "request_invite": "초대를 요청하시겠습니까?",
                 "send": "보내기",
+                "enter_the_vrchat_group_id_to_invite_this_user_to": "이 사용자를 초대하려면 VRChat 그룹 ID를 입력하세요.",
                 "leave_group": "그룹 탈퇴",
                 "leave": "나가기",
                 "leave_selected_groups": "선택한 그룹 탈퇴",
-                "unfriend_user": "사용자를 친구 해제하시겠습니까?",
-                "enter_the_vrchat_group_id_to_invite_this_user_to": "이 사용자를 초대하려면 VRChat 그룹 ID를 입력하세요."
+                "unfriend_user": "사용자를 친구 해제하시겠습니까?"
             },
             "dynamic": {
                 "status_presets_are_limited_to_value": "상태 사전 설정은 {value}로 제한됩니다.",
@@ -4005,6 +4055,11 @@
                 "id": "월드 ID",
                 "copy_id": "ID 복사",
                 "copy_url": "URL 복사",
+                "url": "VRChat 링크",
+                "vrcx_url": "공유 링크",
+                "vrcx_url_description": "이 링크를 열면 VRCX-0 앱이 바로 실행됩니다",
+                "vrcx_share_text": "VRCX-0에서 월드 “{name}” 열기: {url}",
+                "copy_vrcx_url": "공유 링크 복사",
                 "youtube_preview": "YouTube 미리보기",
                 "author_tags": "작성자 태그",
                 "players": "유저 수",
@@ -4027,12 +4082,7 @@
                 "friends_visited": "방문한 친구",
                 "friends_last_visited": "친구 마지막 방문",
                 "persistent_data": "영구 데이터",
-                "cache_size": "캐시 크기",
-                "url": "VRChat 링크",
-                "vrcx_url": "공유 링크",
-                "vrcx_url_description": "이 링크를 열면 VRCX-0 앱이 바로 실행됩니다",
-                "vrcx_share_text": "VRCX-0에서 월드 “{name}” 열기: {url}",
-                "copy_vrcx_url": "공유 링크 복사"
+                "cache_size": "캐시 크기"
             },
             "json": {
                 "header": "JSON"
@@ -4046,12 +4096,16 @@
             "label": {
                 "access": "액세스",
                 "world": "세계",
+                "role_ids": "역할 IDs",
                 "queue_enabled": "대기열이 활성화되었습니다.",
                 "age_gate": "연령 제한",
                 "display_name": "표시 이름",
+                "user_id": "사용자 ID",
                 "strict": "엄격한",
                 "location": "위치",
                 "self_invite": "셀프 초대",
+                "the_instance_was_created_but_vrchat_did_not_return_a_launch_location": "인스턴스가 생성되었지만 VRChat이 시작 위치를 반환하지 않았습니다.",
+                "youtube_preview_must_be_a_video_id_or_valid_url": "YouTube 미리보기는 동영상 ID이거나 유효한 URL이어야 합니다.",
                 "recommended_capacity": "권장 용량",
                 "youtube_preview": "YouTube 미리보기",
                 "author": "작성자",
@@ -4064,11 +4118,7 @@
                 "default_content_settings": "기본 콘텐츠 설정",
                 "manage_domains_allowed_for_this_world_s_video_player": "이 세계의 비디오 플레이어에 허용된 도메인을 관리하세요",
                 "allowed_domain": "허용된 도메인",
-                "instance_created_but_the_new_instance_location_is_not_inviteable": "인스턴스가 생성되었지만 새 인스턴스 위치를 초대할 수 없습니다.",
-                "role_ids": "역할 IDs",
-                "user_id": "사용자 ID",
-                "the_instance_was_created_but_vrchat_did_not_return_a_launch_location": "인스턴스가 생성되었지만 VRChat이 시작 위치를 반환하지 않았습니다.",
-                "youtube_preview_must_be_a_video_id_or_valid_url": "YouTube 미리보기는 동영상 ID이거나 유효한 URL이어야 합니다."
+                "instance_created_but_the_new_instance_location_is_not_inviteable": "인스턴스가 생성되었지만 새 인스턴스 위치를 초대할 수 없습니다."
             },
             "action": {
                 "invite": "초대",
@@ -4076,14 +4126,14 @@
                 "open_in_game": "게임 내에서 열기",
                 "update_world_name_description_capacity_and_preview": "이 세계의 이름, 설명, 용량, 미리보기 업데이트",
                 "change_world_image": "월드 이미지 변경",
+                "reset_your_vrchat_home_location": "VRChat 집 위치 재설정",
                 "edit_managed_content_author_and_feature_tags_for_this_world": "이 세계에 대한 관리 콘텐츠, 작성자 및 기능 태그 편집",
                 "enable_avatar_scaling": "아바타 크기 조정 활성화",
                 "enable_focus_view": "포커스 뷰 활성화",
                 "enable_debugging": "디버깅 활성화",
                 "enable_third_person_view": "3인칭 시점 활성화",
                 "allow_props_to_modify_player_movement": "프롭이 플레이어 이동을 변경하도록 허용",
-                "add_domain": "도메인 추가",
-                "reset_your_vrchat_home_location": "VRChat 집 위치 재설정"
+                "add_domain": "도메인 추가"
             },
             "loading": {
                 "loading_world_profile": "세계 프로필 로드 중",
@@ -4091,33 +4141,33 @@
             },
             "error": {
                 "world_profile_unavailable": "월드 프로필을 사용할 수 없습니다.",
-                "world_cache_location_unavailable": "월드 캐시 위치를 사용할 수 없습니다.",
-                "cannot_self_invite_location_is_not_a_concrete_instance": "직접 초대할 수 없습니다. 위치가 구체적인 인스턴스가 아닙니다.",
-                "failed_to_refresh_the_remote_world_snapshot": "월드 정보를 새로고침하지 못했습니다.",
-                "failed_to_load_the_world_profile": "월드 프로필을 로드하지 못했습니다.",
-                "selected_image_is_too_large": "선택한 이미지가 너무 큽니다.",
-                "selected_file_is_not_an_image": "선택한 파일은 이미지가 아닙니다",
                 "unable_to_open_this_instance_in_vrchat": "VRChat에서 이 인스턴스를 열 수 없습니다.",
+                "world_cache_location_unavailable": "월드 캐시 위치를 사용할 수 없습니다.",
                 "group_id_is_required_for_group_instances": "그룹 인스턴스에는 그룹 ID가 필요합니다.",
+                "cannot_self_invite_location_is_not_a_concrete_instance": "직접 초대할 수 없습니다. 위치가 구체적인 인스턴스가 아닙니다.",
                 "cannot_open_in_vrchat_location_is_not_a_concrete_instance": "VRChat에서 열 수 없습니다. 위치가 구체적인 인스턴스가 아닙니다.",
                 "failed_open_instance_in_vrchat_falling_back_to_self_invite": "VRChat에서 인스턴스 열기에 실패했습니다. 자체 초대로 돌아갑니다.",
-                "world_not_found_description": "세계 {worldId}을(를) 찾을 수 없습니다"
+                "failed_to_refresh_the_remote_world_snapshot": "월드 정보를 새로고침하지 못했습니다.",
+                "failed_to_load_the_world_profile": "월드 프로필을 로드하지 못했습니다.",
+                "world_not_found_description": "세계 {worldId}을(를) 찾을 수 없습니다",
+                "selected_image_is_too_large": "선택한 이미지가 너무 큽니다.",
+                "selected_file_is_not_an_image": "선택한 파일은 이미지가 아닙니다"
             },
             "success": {
                 "world_refreshed": "월드가 새로고침되었습니다",
+                "vrchat_launch_request_sent": "VRChat에서 열었습니다.",
                 "world_cache_deleted": "월드 캐시가 삭제되었습니다.",
                 "world_persistent_data_deleted": "월드 영구 데이터가 삭제되었습니다.",
                 "world_deleted": "월드가 삭제되었습니다.",
                 "instance_created": "인스턴스가 생성되었습니다.",
                 "instance_created_and_self_invite_sent": "인스턴스가 생성되고 자체 초대가 전송됨",
+                "instance_url_copied": "인스턴스 URL 복사됨",
                 "world_details_updated": "세계 세부 정보가 업데이트되었습니다.",
                 "world_image_updated": "월드 이미지가 업데이트되었습니다.",
                 "world_description_updated": "세계 설명이 업데이트되었습니다.",
                 "youtube_preview_updated": "YouTube 미리보기가 업데이트되었습니다.",
                 "world_tags_updated": "세계 태그가 업데이트되었습니다.",
-                "allowed_domains_updated": "허용된 도메인이 업데이트되었습니다.",
-                "vrchat_launch_request_sent": "VRChat에서 열었습니다.",
-                "instance_url_copied": "인스턴스 URL 복사됨"
+                "allowed_domains_updated": "허용된 도메인이 업데이트되었습니다."
             },
             "description": {
                 "edit_world_details": "세계 세부정보 편집",
@@ -4130,6 +4180,7 @@
             },
             "toast": {
                 "failed_to_refresh_world": "세계를 새로 고치지 못했습니다.",
+                "failed_to_launch_vrchat_instance": "VRChat 인스턴스를 시작하지 못했습니다.",
                 "home_world_reset": "홈 월드 재설정",
                 "failed_to_update_home_world": "홈 월드를 업데이트하지 못했습니다.",
                 "memo_saved": "로컬 메모가 저장되었습니다.",
@@ -4143,8 +4194,10 @@
                 "failed_to_delete_world_persistent_data": "월드 영구 데이터를 삭제하지 못했습니다.",
                 "failed_to_delete_world": "월드를 삭제하지 못했습니다.",
                 "failed_to_load_new_instance_settings": "새 인스턴스 설정을 로드하지 못했습니다.",
+                "instance_created_but_self_invite_failed_value": "인스턴스가 생성되었지만 자체 초대에 실패했습니다: {value}",
                 "instance_created_but_self_invite_failed": "인스턴스가 생성되었지만 자체 초대에 실패했습니다.",
                 "failed_to_send_self_invite": "본인 초대를 보내지 못했습니다.",
+                "failed_to_open_instance_in_vrchat": "VRChat에서 인스턴스를 열지 못했습니다.",
                 "failed_to_rename_world": "세계 이름을 바꾸지 못했습니다.",
                 "failed_to_update_world_details": "세계 세부 정보를 업데이트하지 못했습니다.",
                 "failed_to_update_world_description": "세계 설명을 업데이트하지 못했습니다.",
@@ -4152,10 +4205,7 @@
                 "failed_to_update_world_tags": "세계 태그를 업데이트하지 못했습니다.",
                 "failed_to_update_allowed_domains": "허용된 도메인을 업데이트하지 못했습니다.",
                 "failed_to_upload_world_image": "월드 이미지 업로드 실패",
-                "translation_failed": "번역 실패",
-                "failed_to_launch_vrchat_instance": "VRChat 인스턴스를 시작하지 못했습니다.",
-                "instance_created_but_self_invite_failed_value": "인스턴스가 생성되었지만 자체 초대에 실패했습니다: {value}",
-                "failed_to_open_instance_in_vrchat": "VRChat에서 인스턴스를 열지 못했습니다."
+                "translation_failed": "번역 실패"
             },
             "modal": {
                 "edit_local_memo": "로컬 메모 수정",
@@ -4214,7 +4264,12 @@
                 "description": "설명",
                 "id": "아바타 ID",
                 "copy_id": "ID 복사",
+                "url": "VRChat 링크",
                 "copy_url": "URL 복사",
+                "vrcx_url": "공유 링크",
+                "vrcx_url_description": "이 링크를 열면 VRCX-0 앱이 바로 실행됩니다",
+                "vrcx_share_text": "VRCX-0에서 아바타 “{name}” 열기: {url}",
+                "copy_vrcx_url": "공유 링크 복사",
                 "created_at": "최초 업로드",
                 "last_updated": "마지막 업데이트",
                 "version": "버전",
@@ -4229,17 +4284,24 @@
                 "memo_placeholder": "-",
                 "listings": "목록",
                 "gallery": "갤러리",
-                "url": "VRChat 링크",
-                "vrcx_url": "공유 링크",
-                "vrcx_url_description": "이 링크를 열면 VRCX-0 앱이 바로 실행됩니다",
-                "vrcx_share_text": "VRCX-0에서 아바타 “{name}” 열기: {url}",
-                "copy_vrcx_url": "공유 링크 복사",
                 "attributes": "속성"
             },
             "performance": {
                 "header": "성능",
                 "rating": "등급",
+                "download_size": "다운로드 크기",
+                "uncompressed_size": "비압축 크기",
+                "texture_memory": "텍스처 메모리",
                 "analysis_loading": "상세 성능 분석을 불러오는 중…",
+                "ranks": {
+                    "Excellent": "Excellent",
+                    "Good": "Good",
+                    "Medium": "Medium",
+                    "Poor": "Poor",
+                    "VeryPoor": "Very Poor"
+                },
+                "pc_rules": "PC 성능 규칙",
+                "mobile_rules": "Android / iOS 성능 규칙",
                 "analysis_pending": "상세 성능 분석이 아직 준비되지 않았습니다. 아바타를 새로고침하여 다시 시도하세요.",
                 "analysis_unavailable": "이 플랫폼에서는 상세 성능 분석을 사용할 수 없습니다.",
                 "yes": "예",
@@ -4248,6 +4310,38 @@
                     "geometry": "지오메트리",
                     "dynamics": "다이내믹스 및 제약 조건",
                     "components": "컴포넌트 및 효과"
+                },
+                "stat": {
+                    "triangles": "Triangles",
+                    "vertices": "Vertices",
+                    "skinned_meshes": "Skinned meshes",
+                    "basic_meshes": "Basic meshes",
+                    "material_slots": "Material slots",
+                    "bones": "Bones",
+                    "blend_shapes": "Blend shapes",
+                    "bounds": "Bounds",
+                    "physbone_components": "PhysBone components",
+                    "affected_transforms": "PhysBone transforms",
+                    "physbone_colliders": "PhysBone colliders",
+                    "collision_checks": "PhysBone collision check count",
+                    "contacts": "Contact count",
+                    "constraints": "Constraints",
+                    "constraint_depth": "Constraint depth",
+                    "animators": "Animators",
+                    "particle_systems": "Particle systems",
+                    "max_particles": "Total max particles",
+                    "mesh_particle_triangles": "Mesh particle triangles",
+                    "lights": "Lights",
+                    "audio_sources": "Audio sources",
+                    "raycasts": "Raycasts",
+                    "cloths": "Cloth meshes",
+                    "cloth_vertices": "Cloth max vertices",
+                    "trail_renderers": "Trail renderers",
+                    "line_renderers": "Line renderers",
+                    "physics_colliders": "Collider count",
+                    "rigidbodies": "Rigidbodies",
+                    "particle_trails": "Particle trails",
+                    "particle_collision": "Particle collisions"
                 }
             },
             "json": {
@@ -4278,10 +4372,10 @@
             "label": {
                 "avatar_gallery_image_uploaded": "아바타 갤러리 이미지가 업로드되었습니다.",
                 "local_tags": "로컬 태그",
+                "vrchat_tags": "VRChat 태그",
                 "built_in_content_tags": "내장 콘텐츠 태그",
                 "raw_content_tags": "원시 콘텐츠 태그",
-                "none": "없음",
-                "vrchat_tags": "VRChat 태그"
+                "none": "없음"
             },
             "action": {
                 "change_avatar_image": "아바타 이미지 변경",
@@ -4302,6 +4396,7 @@
                 "failed_to_load_avatar_styles": "아바타 스타일을 로드하지 못했습니다.",
                 "failed_to_update_avatar_details": "아바타 세부정보를 업데이트하지 못했습니다.",
                 "failed_to_delete_avatar": "아바타를 삭제하지 못했습니다.",
+                "value_avatar_state_refresh_failed": "{value} 아바타 상태 새로 고침 실패",
                 "avatar_unblocked": "아바타가 차단 해제되었습니다.",
                 "failed_to_update_avatar_moderation": "아바타 검토를 업데이트하지 못했습니다.",
                 "memo_saved": "로컬 메모가 저장되었습니다.",
@@ -4319,8 +4414,7 @@
                 "failed_to_delete_impostor": "임포스터를 삭제하지 못했습니다.",
                 "impostor_queued_for_regeneration": "재생성 대기 중인 임포스터",
                 "failed_to_regenerate_impostor": "임포스터를 재생성하지 못했습니다.",
-                "avatar_deleted_but_current_user_snapshot_refresh": "아바타를 삭제했지만 아바타 목록을 새로고침하지 못했습니다.",
-                "value_avatar_state_refresh_failed": "{value} 아바타 상태 새로 고침 실패"
+                "avatar_deleted_but_current_user_snapshot_refresh": "아바타를 삭제했지만 아바타 목록을 새로고침하지 못했습니다."
             },
             "modal": {
                 "select_fallback_avatar": "대체 아바타를 선택하시겠습니까?",
@@ -4432,8 +4526,8 @@
             },
             "loading": {
                 "loading_group_profile": "그룹 프로필 로드 중",
-                "loading": "로드 중...",
-                "fetching_the_current_vrchat_group_snapshot_for_this_dialog": "그룹 정보 불러오는 중"
+                "fetching_the_current_vrchat_group_snapshot_for_this_dialog": "그룹 정보 불러오는 중",
+                "loading": "로드 중..."
             },
             "error": {
                 "group_profile_unavailable": "그룹 프로필을 사용할 수 없습니다.",
@@ -4447,6 +4541,9 @@
                 "no_rows": "행 없음",
                 "no_roles": "역할 없음",
                 "no_gallery_images": "갤러리 이미지 없음"
+            },
+            "description": {
+                "group_snapshot_unavailable_description": "그룹 정보를 불러오지 못했습니다."
             },
             "label": {
                 "group_left": "그룹 탈퇴함",
@@ -4493,24 +4590,21 @@
                 "group_blocked": "그룹이 차단됨",
                 "group_unblocked": "그룹이 차단 해제되었습니다.",
                 "failed_to_update_group_block_state": "그룹 차단 상태를 업데이트하지 못했습니다.",
+                "value_failed": "{value} 실패",
                 "group_post_updated": "그룹 게시물이 업데이트되었습니다.",
                 "group_post_created": "그룹 게시물이 생성되었습니다.",
                 "failed_to_save_group_post": "그룹 게시물을 저장하지 못했습니다.",
                 "failed_to_send_group_invite": "그룹 초대를 보내지 못했습니다.",
-                "failed_to_delete_group_post": "그룹 게시물을 삭제하지 못했습니다.",
-                "value_failed": "{value} 실패"
+                "failed_to_delete_group_post": "그룹 게시물을 삭제하지 못했습니다."
             },
             "modal": {
                 "leave_group": "그룹을 탈퇴하시겠습니까?",
                 "leave": "탈퇴",
+                "enter_the_vrchat_user_id_to_invite": "초대하려면 VRChat 사용자 ID를 입력하세요.",
                 "delete_group_post": "그룹 게시물을 삭제하시겠습니까?",
                 "block_group": "그룹을 차단하시겠습니까?",
                 "unblock_group": "그룹을 차단 해제하시겠습니까?",
-                "invite_to_group": "그룹에 초대",
-                "enter_the_vrchat_user_id_to_invite": "초대하려면 VRChat 사용자 ID를 입력하세요."
-            },
-            "description": {
-                "group_snapshot_unavailable_description": "그룹 정보를 불러오지 못했습니다."
+                "invite_to_group": "그룹에 초대"
             },
             "dynamic": {
                 "leave_value": "{value}을(를) 떠나시겠습니까?",
@@ -4677,9 +4771,9 @@
         },
         "export_friends_list": {
             "header": "친구 목록 내보내기",
+            "description": "현재 친구 목록을 CSV 또는 JSON으로 내보냅니다.",
             "csv": "CSV",
-            "json": "JSON",
-            "description": "현재 친구 목록을 CSV 또는 JSON으로 내보냅니다."
+            "json": "JSON"
         },
         "export_own_avatars": {
             "header": "내 아바타 목록 내보내기",
@@ -4737,6 +4831,7 @@
             "profile_icons_managed_link": "프로필 아이콘은 갤러리에서 관리됩니다.",
             "emoji_animation_styles": "애니메이션 스타일",
             "emoji_animation_type": "애니메이션 이모티콘",
+            "emoji_animation_fps": "FPS:",
             "emoji_animation_frame_count": "프레임 수:",
             "emoji_loop_pingpong": "핑퐁 루프",
             "flipbook_info": "애니메이션 이모티콘으로 사용할 1024x1024 PNG 스프라이트 시트를 선택하세요. 사용 가능한 프레임 그리드 크기: 4, 16 또는 64(최대 FPS 64, 최대 프레임 64)",
@@ -4757,8 +4852,7 @@
                 "compact": "콤팩트",
                 "dense": "조밀한"
             },
-            "crop_image": "업로드 확인",
-            "emoji_animation_fps": "FPS:"
+            "crop_image": "업로드 확인"
         },
         "inventory": {
             "header": "인벤토리",
@@ -4838,8 +4932,8 @@
             "search_type_placeholder": "검색 유형",
             "search_types": {
                 "player_name": "플레이어 이름",
-                "world_name": "세계 이름",
                 "player_id": "플레이어 ID",
+                "world_name": "세계 이름",
                 "world_id": "세계 ID"
             },
             "no_results": "검색결과가 없습니다",
@@ -4847,6 +4941,7 @@
             "layout_grid": "이미지 그리드",
             "layout_list": "정보 목록",
             "clear_search": "검색 지우기",
+            "invalid_file": "잘못된 파일이 선택되었습니다. 유효한 VRChat 스크린샷을 선택하세요.",
             "section_location": "위치",
             "section_players": "플레이어",
             "section_file_info": "파일 정보",
@@ -4858,28 +4953,27 @@
             "col_resolution": "해상도",
             "col_match": "일치",
             "col_author": "작성자",
+            "source": "출처",
+            "back_to_results": "{count} 결과로 돌아가기",
+            "result_count": "{count} 결과",
             "gallery": "갤러리",
             "folders": "폴더",
             "scanning": "스크린샷 스캔 중",
+            "image_count": "{count} 이미지",
+            "feeling_lucky": "랜덤으로 한 장",
+            "exporting_progress": "내보내는 중 {done}/{total}",
+            "export_finalizing": "마무리하는 중",
             "empty_gallery": "이 폴더에는 스크린샷이 없습니다.",
             "empty_gallery_description": "다른 폴더를 선택하거나 스크린샷 라이브러리를 새로 고치세요.",
             "empty_folders": "스크린샷 폴더 없음",
+            "empty_folders_description": "VRChat에서 스크린샷을 저장한 후 새로고침하세요.",
             "loading_gallery": "스크린샷 로드 중",
             "loading_gallery_description": "색인이 생성된 스크린샷 목록을 읽는 중입니다.",
             "gallery_load_failed": "스크린샷 갤러리를 로드하지 못했습니다.",
             "scan_failed": "스크린샷 라이브러리를 스캔하지 못했습니다.",
             "thumbnail_failed": "미리보기 이미지를 사용할 수 없습니다.",
             "hide_details": "이미지 정보 숨기기",
-            "show_details": "이미지 정보 표시",
-            "invalid_file": "잘못된 파일이 선택되었습니다. 유효한 VRChat 스크린샷을 선택하세요.",
-            "source": "출처",
-            "back_to_results": "{count} 결과로 돌아가기",
-            "result_count": "{count} 결과",
-            "image_count": "{count} 이미지",
-            "feeling_lucky": "랜덤으로 한 장",
-            "exporting_progress": "내보내는 중 {done}/{total}",
-            "export_finalizing": "마무리하는 중",
-            "empty_folders_description": "VRChat에서 스크린샷을 저장한 후 새로고침하세요."
+            "show_details": "이미지 정보 표시"
         },
         "set_avatar_styles": {
             "header": "아바타 스타일 설정",
@@ -4927,6 +5021,8 @@
             "msg_test_failed": "잘못된 YouTube API 키"
         },
         "translation_api": {
+            "header": "번역 제공업체 설정",
+            "description": "콘텐츠 번역에 사용할 제공업체를 선택하고 설정하세요.",
             "guide": "가이드",
             "mode": "제공업체",
             "mode_google": "구글 번역",
@@ -4949,9 +5045,7 @@
             },
             "deepl": {
                 "api_key": "DeepL API 키"
-            },
-            "header": "번역 제공업체 설정",
-            "description": "콘텐츠 번역에 사용할 제공업체를 선택하고 설정하세요."
+            }
         },
         "shared_feed_filters": {
             "notification": "알림 필터",
@@ -5112,12 +5206,14 @@
             "label": {
                 "showing_recent_only": "최근 {count}건만 표시 중 — 전체 기록 열기",
                 "search_limited_to_recent": "최근 {count}건에서 검색 중 — 전체 기록에서 검색",
+                "players_count": "{count} 플레이어",
                 "recorded_instance_visits": "기록된 인스턴스 방문",
+                "recorded_instance_visits_count": "{count} 기록된 인스턴스 방문.",
                 "rows": "행",
                 "location": "위치",
                 "page": "페이지",
-                "players_count": "{count} 플레이어",
-                "recorded_instance_visits_count": "{count} 기록된 인스턴스 방문."
+                "sort_by": "정렬 기준",
+                "sort_descending": "내림차순 정렬"
             },
             "success": {
                 "instance_id_copied": "인스턴스 ID를 복사했습니다",
@@ -5206,8 +5302,8 @@
                 "description": "설명",
                 "export_to_calendar": "캘린더로 내보내기",
                 "download_ics": ".ics 다운로드",
-                "untitled_event": "제목 없는 이벤트",
-                "copied_event_link": "캘린더 일정 URL이 클립보드에 복사되었습니다."
+                "copied_event_link": "캘린더 일정 URL이 클립보드에 복사되었습니다.",
+                "untitled_event": "제목 없는 이벤트"
             },
             "featured_events": "주요 이벤트",
             "events_count_short": "{count} 이벤트",
@@ -5235,7 +5331,18 @@
             }
         },
         "change_log": {
-            "header": "변경사항"
+            "header": "변경사항",
+            "support_title": "VRCX-0가 도움이 되었다면",
+            "support_description": "GitHub 스타는 프로젝트를 후원하는 가장 쉬운 방법입니다.",
+            "star_on_github": "GitHub에서 스타 주기",
+            "support_development": "개발자 후원하기",
+            "loading": "변경 사항을 불러오는 중...",
+            "failed_to_load": "변경 사항을 불러오지 못했습니다.",
+            "latest_release": "최신 릴리스",
+            "empty": "이 릴리스에는 변경 사항이 없습니다.",
+            "toast_title": "{value}(으)로 업데이트됨",
+            "toast_description": "이번 버전에서 변경된 내용을 확인하세요.",
+            "view_changes": "변경 사항 보기"
         },
         "open_source": {
             "header": "오픈 소스 소프트웨어 안내",
@@ -5244,13 +5351,14 @@
             "search_placeholder": "패키지, 버전 또는 라이선스 검색",
             "notice_location_prefix": "앱 디렉터리의 전체 알림 파일 위치:",
             "open_project": "프로젝트 열기",
+            "open_license_url": "오픈 라이선스 URL",
             "notice_unavailable": "이 항목에는 로컬 라이선스 텍스트가 없습니다. 전체 알림 파일에서 이 종속성 알림을 찾을 수 있습니다.",
             "select_package": "세부정보를 보려면 패키지를 선택하세요.",
             "no_results": "일치하는 패키지를 찾을 수 없습니다.",
-            "no_version": "버전 메타데이터 없음",
-            "open_license_url": "오픈 라이선스 URL"
+            "no_version": "버전 메타데이터 없음"
         },
         "registry_backup": {
+            "header": "VRChat 레지스트리 설정 백업",
             "backup": "백업",
             "restore": "복원",
             "save_to_file": "파일에 저장",
@@ -5260,7 +5368,6 @@
             "name": "이름",
             "date": "날짜",
             "auto_backup": "3일마다 자동 백업(2주 후 삭제)",
-            "header": "VRChat 레지스트리 설정 백업",
             "ask_to_restore": "VRChat 레지스트리 설정이 없을 때 복원 요청"
         },
         "avatar_database_provider": {
@@ -5275,15 +5382,18 @@
                 "clear_errors": "오류 지우기",
                 "exclude": "제외"
             },
+            "description": {
+                "paste_exported_ids_process_the_list_then_import_to_a_vrchat_or_local_favorite_group": "내보낸 ID를 붙여넣고 목록을 처리한 다음 VRChat 즐겨찾기 그룹 또는 로컬 즐겨찾기 그룹으로 가져옵니다."
+            },
             "label": {
                 "process_list": "프로세스 목록",
+                "vrchat_group": "VRChat 그룹",
                 "local_group": "로컬 그룹",
                 "image": "이미지",
                 "name": "이름",
                 "detail": "세부정보",
                 "actions": "작업",
                 "rows_yet": "아직 행",
-                "vrchat_group": "VRChat 그룹",
                 "import_to": "가져올 위치",
                 "local": "로컬",
                 "select_group": "그룹 선택"
@@ -5300,9 +5410,6 @@
             },
             "empty": {
                 "no_parsed": "파싱되지 않음"
-            },
-            "description": {
-                "paste_exported_ids_process_the_list_then_import_to_a_vrchat_or_local_favorite_group": "내보낸 ID를 붙여넣고 목록을 처리한 다음 VRChat 즐겨찾기 그룹 또는 로컬 즐겨찾기 그룹으로 가져옵니다."
             }
         },
         "tools": {
@@ -5327,6 +5434,10 @@
             }
         },
         "system": {
+            "label": {
+                "vrcx_0_update": "VRCX-0 업데이트",
+                "fps_144": "--fps=144"
+            },
             "action": {
                 "update_path": "업그레이드",
                 "install_and_restart": "설치 및 다시 시작",
@@ -5339,10 +5450,6 @@
                 "updated_launch_options": "업데이트된 실행 옵션",
                 "saved_vrchat_config": "VRChat 구성이 저장되었습니다."
             },
-            "label": {
-                "vrcx_0_update": "VRCX-0 업데이트",
-                "fps_144": "--fps=144"
-            },
             "dynamic": {
                 "version_summary": "현재 버전 {current}. 최신 버전 {latest}."
             }
@@ -5352,12 +5459,12 @@
                 "closed_at": "종료 시각:",
                 "open_for_at_least": "열린 지 {duration} 이상 경과",
                 "android": "안드로이드:",
+                "ios": "iOS:",
                 "game_version": "게임 버전",
                 "instance_queuing_enabled": "인스턴스 대기열 활성화",
                 "disabled_content": "비활성화된 콘텐츠",
                 "instance_closed": "인스턴스가 닫혔습니다.",
-                "self_invite": "본인 초대",
-                "ios": "iOS:"
+                "self_invite": "본인 초대"
             },
             "action": {
                 "close_instance": "인스턴스 닫기",
@@ -5383,9 +5490,9 @@
         },
         "instance_invite": {
             "toast": {
-                "failed_to_send_invite": "초대장을 보내지 못했습니다.",
                 "sent_value_invites": "{value} 초대를 보냈습니다.",
-                "failed_to_send_value_invites": "{value} 초대를 보내지 못했습니다."
+                "failed_to_send_value_invites": "{value} 초대를 보내지 못했습니다.",
+                "failed_to_send_invite": "초대장을 보내지 못했습니다."
             },
             "modal": {
                 "send_invite": "초대장을 보내시겠습니까?",
@@ -5427,9 +5534,9 @@
         "otp": {
             "header": "2단계 인증",
             "description": "복구 코드 중 하나를 입력하세요",
+            "use_totp": "TOTP 사용",
             "verify": "확인",
-            "input_error": "잘못된 코드",
-            "use_totp": "TOTP 사용"
+            "input_error": "잘못된 코드"
         },
         "email_otp": {
             "header": "2단계 인증",
@@ -5440,10 +5547,10 @@
         },
         "direct_access_omni": {
             "header": "빠른 접근",
+            "description_failed": "직접 액세스에 실패했습니다. URL 또는 ID를 확인하고 다시 시도하세요.",
             "message": {
                 "opening": "여는 중..."
-            },
-            "description_failed": "직접 액세스에 실패했습니다. URL 또는 ID를 확인하고 다시 시도하세요."
+            }
         },
         "rename_world": {
             "message": {
@@ -5467,8 +5574,8 @@
         },
         "proxy_settings": {
             "header": "프록시 설정",
-            "restart": "저장 및 다시 시작",
             "description": "프록시 서버 주소와 포트를 입력하세요. 127.0.0.1:7890, http://127.0.0.1:7890, socks5://127.0.0.1:7890 형식을 지원합니다.",
+            "restart": "저장 및 다시 시작",
             "enabled": "프록시 사용",
             "enabled_description": "주소 없이 활성화하면 VRCX-0이(가) 직접 연결하며 프록시 스위치는 켜진 상태로 유지됩니다.",
             "address": "프록시 주소",
@@ -5491,34 +5598,38 @@
             "header": "최대 테이블 크기",
             "description": "데이터베이스에서 UI로 불러오는 VRCX-0 로그 항목 수를 제한합니다. 값이 크면 RAM 사용량과 성능에 영향을 줄 수 있습니다.",
             "table_max_entries": "최대 테이블 크기",
-            "search_limit_returns": "검색 제한 반환",
-            "search_limit_returns_warning": "값이 너무 크면 앱이 정지될 수 있습니다.",
-            "cancel": "취소",
-            "save": "저장",
             "table_max_entries_error": "{min}에서 {max} 사이의 숫자를 입력하세요.",
             "table_max_entries_hint": "유효한 범위: {min} – {max}",
+            "search_limit_returns": "검색 제한 반환",
             "search_limit_returns_error": "{min}에서 {max} 사이의 숫자를 입력하세요.",
-            "search_limit_returns_hint": "유효한 범위: {min} – {max}"
+            "search_limit_returns_hint": "유효한 범위: {min} – {max}",
+            "search_limit_returns_warning": "값이 너무 크면 앱이 정지될 수 있습니다.",
+            "cancel": "취소",
+            "save": "저장"
         }
     },
     "message": {
+        "auto_login_delay_countdown": "{seconds}s에 자동 로그인...",
         "auth": {
+            "logout_greeting": "또 만나요, {name}!",
             "account_removed": "계정이 삭제됨",
             "auto_login_success": "자동으로 로그인됨",
             "auto_login_failed": "자동 로그인에 실패했습니다",
-            "offline": "오프라인 상태입니다",
-            "logout_greeting": "또 만나요, {name}!",
             "session_expired": "VRChat 세션이 만료되었습니다. 로그인으로 돌아갑니다.",
-            "session_restore_available": "저장된 계정을 사용할 수 있는 경우 VRCX-0은(는) 자동으로 다시 로그인을 시도합니다."
+            "session_restore_available": "저장된 계정을 사용할 수 있는 경우 VRCX-0은(는) 자동으로 다시 로그인을 시도합니다.",
+            "offline": "오프라인 상태입니다"
         },
         "vrcx_updater": {
+            "failed": "업데이트를 확인하지 못했습니다. {message}",
             "failed_install": "업데이트를 설치하지 못했습니다.",
+            "current_version": "현재 버전",
+            "latest_version": "최신 버전",
+            "released": "출시일",
             "checking_update_state": "업데이트 상태를 확인하는 중입니다.",
             "no_downloadable_releases_found": "다운로드 가능한 릴리스가 없습니다.",
             "no_releases_found": "릴리스를 찾을 수 없습니다.",
             "failed_to_load_update_releases": "업데이트 릴리스를 로드하지 못했습니다.",
-            "installing_update": "업데이트를 설치 중입니다.",
-            "failed": "업데이트를 확인하지 못했습니다. {message}"
+            "installing_update": "업데이트를 설치 중입니다."
         },
         "badge": {
             "updated": "배지가 업데이트되었습니다."
@@ -5531,30 +5642,18 @@
             "deleted": "아바타가 삭제되었습니다."
         },
         "database": {
-            "migration_skip": "건너뛰기",
-            "migration_restarting_title": "데이터 마이그레이션",
-            "upgrade_in_progress_title": "데이터베이스 업그레이드 진행 중",
-            "maintenance_in_progress_title": "데이터베이스 정리 중",
-            "maintenance_in_progress_description": "디스크 공간을 정리하고 있습니다. 완료될 때까지 데이터베이스 접근이 일시 중지됩니다.",
-            "upgrade_failed_title": "데이터베이스 업그레이드 실패",
-            "failure_record": "실패 기록",
-            "failure_record_hint": "GitHub에 문제를 보고할 때 error-log.txt를 첨부하세요. 로그에 로컬 경로와 계정 관련 정보가 포함될 수 있으므로 먼저 확인하세요.",
-            "open_failure_log_folder": "로그 폴더 열기",
-            "create_github_issue": "GitHub Issue 만들기",
-            "preserved_work_database": "보존된 업그레이드 작업 데이터베이스",
-            "database_upload_warning": "이 데이터베이스에는 계정 및 활동 관련 개인정보가 포함될 수 있습니다. GitHub에 업로드하지 마세요.",
-            "use_new_database": "새 데이터베이스 사용",
-            "fresh_start_confirm_title": "새 데이터베이스를 사용하시겠습니까?",
-            "fresh_start_confirm_description": "VRCX-0은 현재 데이터베이스와 업그레이드 실패 파일을 복구 폴더에 보관한 뒤 비어 있는 새 데이터베이스로 다시 시작합니다. 설정, 로컬 기록 및 저장된 계정 데이터는 새 데이터베이스로 이전되지 않습니다.",
-            "fresh_start_restarting": "현재 데이터베이스를 보관하고 VRCX-0을 다시 시작하는 중...",
-            "fresh_start_failed": "새 데이터베이스를 만들 수 없습니다.",
             "migration_found_title": "기존 VRCX 데이터베이스가 감지되었습니다.",
             "migration_found_description": "이 컴퓨터에서 기존 VRCX 데이터베이스를 찾았습니다. VRCX-0(으)로 마이그레이션하시겠습니까? 원본 VRCX 데이터는 수정되지 않습니다.",
             "legacy_vrcx_running_title": "VRCX가 실행 중입니다",
             "legacy_vrcx_running_description": "VRCX-0에서 VRCX가 아직 실행 중인 것을 감지했습니다. 종료한 후 ‘다시 시도’를 선택하세요. 강제 마이그레이션은 실패할 수 있습니다.",
             "legacy_vrcx_check_again": "다시 시도",
             "legacy_vrcx_force_migration": "강제 마이그레이션",
+            "migration_skip": "건너뛰기",
+            "migration_restarting_title": "데이터 마이그레이션",
             "migration_restarting": "VRCX-0이(가) 다시 시작되어 마이그레이션을 완료합니다...",
+            "upgrade_in_progress_title": "데이터베이스 업그레이드 진행 중",
+            "maintenance_in_progress_title": "데이터베이스 정리 중",
+            "maintenance_in_progress_description": "디스크 공간을 정리하고 있습니다. 완료될 때까지 데이터베이스 접근이 일시 중지됩니다.",
             "upgrade_stage": {
                 "preflight": "데이터베이스를 확인하는 중",
                 "prepare_legacy_snapshot": "VRCX 데이터베이스의 일관된 복사본을 만드는 중",
@@ -5571,6 +5670,18 @@
                 "write_version": "데이터베이스 버전을 기록하는 중",
                 "commit": "업그레이드된 데이터베이스로 전환하는 중"
             },
+            "upgrade_failed_title": "데이터베이스 업그레이드 실패",
+            "failure_record": "실패 기록",
+            "failure_record_hint": "GitHub에 문제를 보고할 때 error-log.txt를 첨부하세요. 로그에 로컬 경로와 계정 관련 정보가 포함될 수 있으므로 먼저 확인하세요.",
+            "open_failure_log_folder": "로그 폴더 열기",
+            "create_github_issue": "GitHub Issue 만들기",
+            "preserved_work_database": "보존된 업그레이드 작업 데이터베이스",
+            "database_upload_warning": "이 데이터베이스에는 계정 및 활동 관련 개인정보가 포함될 수 있습니다. GitHub에 업로드하지 마세요.",
+            "use_new_database": "새 데이터베이스 사용",
+            "fresh_start_confirm_title": "새 데이터베이스를 사용하시겠습니까?",
+            "fresh_start_confirm_description": "VRCX-0은 현재 데이터베이스와 업그레이드 실패 파일을 복구 폴더에 보관한 뒤 비어 있는 새 데이터베이스로 다시 시작합니다. 설정, 로컬 기록 및 저장된 계정 데이터는 새 데이터베이스로 이전되지 않습니다.",
+            "fresh_start_restarting": "현재 데이터베이스를 보관하고 VRCX-0을 다시 시작하는 중...",
+            "fresh_start_failed": "새 데이터베이스를 만들 수 없습니다.",
             "upgrade_keep_open": "완료될 때까지 VRCX-0을 닫지 마세요.",
             "failure_reason": "원인",
             "restart_app": "VRCX-0 다시 시작"
@@ -5591,6 +5702,9 @@
             "sent": "초대장이 전송되었습니다",
             "message_updated": "초대 메시지가 업데이트되었습니다."
         },
+        "launch": {
+            "invalid_path": "잘못된 경로입니다. VRChat 폴더 또는 launch.exe를 입력해야 합니다."
+        },
         "gallery": {
             "uploaded": "갤러리 이미지가 업로드되었습니다.",
             "failed": "갤러리 이미지를 업로드하지 못했습니다.",
@@ -5606,6 +5720,9 @@
             "home_updated": "홈 월드가 업데이트되었습니다.",
             "id_copied": "월드 ID가 클립보드에 복사되었습니다.",
             "url_copied": "월드 URL이 클립보드에 복사되었습니다."
+        },
+        "vrcplus": {
+            "required": "VRC+"
         },
         "screenshot_metadata": {
             "deleted": "스크린샷 메타데이터가 삭제되었습니다.",
@@ -5651,15 +5768,6 @@
                 "failed_to_read_image": "이미지를 읽지 못했습니다."
             }
         },
-        "error": "오류",
-        "update_success": "업데이트 성공",
-        "auto_login_delay_countdown": "{seconds}s에 자동 로그인...",
-        "launch": {
-            "invalid_path": "잘못된 경로입니다. VRChat 폴더 또는 launch.exe를 입력해야 합니다."
-        },
-        "vrcplus": {
-            "required": "VRC+"
-        },
         "registry": {
             "restored": "VRChat 레지스트리 설정이 복원되었습니다.",
             "deleted": "기존 VRChat 레지스트리 설정이 삭제되었습니다.",
@@ -5670,7 +5778,9 @@
         },
         "gamelog": {
             "vrchat_must_be_closed": "이 옵션을 변경하려면 VRChat을(를) 닫아야 합니다."
-        }
+        },
+        "error": "오류",
+        "update_success": "업데이트 성공"
     },
     "notifications": {
         "has_joined": "가입했습니다",
@@ -5678,11 +5788,21 @@
         "joined_with_others": "외 {count}명이 참가했습니다",
         "left_with_others": "외 {count}명이 떠났습니다",
         "is_joining": "합류 중",
+        "gps": "{location}에 있습니다",
+        "online_location": "{location}에 로그인했습니다.",
         "online": "로그인했습니다",
         "offline": "로그아웃했습니다",
+        "status_update": "현재 상태는 {status} {description}입니다.",
+        "invite": "님이 {location}에 초대했습니다 {message}",
+        "request_invite": "{message}님이 초대를 요청했습니다.",
+        "invite_response": "초대에 응답했습니다 {message}",
+        "request_invite_response": "초대 요청에 응답했습니다 {message}",
         "friend_request": "님이 친구 요청을 보냈습니다",
         "friend": "님이 이제 친구가 되었습니다",
         "unfriend": "님이 더 이상 친구가 아닙니다",
+        "trust_level": "현재 신뢰 수준은 {trustLevel}입니다.",
+        "display_name": "이름을 {displayName}(으)로 변경했습니다.",
+        "bio": "업데이트된 약력",
         "group_announcement_title": "그룹 공지",
         "group_informative_title": "그룹 정보",
         "group_invite_title": "그룹 초대",
@@ -5693,7 +5813,13 @@
         "group_instance_opened_location": "새 인스턴스를 생성했습니다: {location}",
         "group_instances_opened": "새 인스턴스 {count}개를 생성했습니다",
         "instance_closed_title": "인스턴스가 닫혔습니다.",
+        "event_title": "이벤트",
+        "external_title": "외부 앱",
+        "video_play_title": "비디오 재생",
+        "portal_spawn_name": "{location}에 대한 포털을 생성했습니다.",
         "portal_spawn": "사용자가 포털을 생성했습니다.",
+        "avatar_change": "아바타 {avatar}로 변경됨",
+        "chat_message": "말했다: {message}",
         "blocked_player_joined": "차단된 사용자가 가입했습니다",
         "blocked_player_left": "차단된 사용자가 떠났습니다.",
         "muted_player_joined": "음소거된 사용자가 합류했습니다",
@@ -5701,23 +5827,7 @@
         "blocked": "님이 당신을 차단했습니다",
         "unblocked": "님이 당신을 차단 해제했습니다",
         "muted": "님이 당신을 음소거했습니다",
-        "unmuted": "님이 음소거를 해제했습니다",
-        "gps": "{location}에 있습니다",
-        "online_location": "{location}에 로그인했습니다.",
-        "status_update": "현재 상태는 {status} {description}입니다.",
-        "invite": "님이 {location}에 초대했습니다 {message}",
-        "request_invite": "{message}님이 초대를 요청했습니다.",
-        "invite_response": "초대에 응답했습니다 {message}",
-        "request_invite_response": "초대 요청에 응답했습니다 {message}",
-        "trust_level": "현재 신뢰 수준은 {trustLevel}입니다.",
-        "display_name": "이름을 {displayName}(으)로 변경했습니다.",
-        "bio": "업데이트된 약력",
-        "event_title": "이벤트",
-        "external_title": "외부 앱",
-        "video_play_title": "비디오 재생",
-        "portal_spawn_name": "{location}에 대한 포털을 생성했습니다.",
-        "avatar_change": "아바타 {avatar}로 변경됨",
-        "chat_message": "말했다: {message}"
+        "unmuted": "님이 음소거를 해제했습니다"
     },
     "location": {
         "offline": "오프라인",
@@ -5872,9 +5982,11 @@
         "do_not_disturb_failed": "방해 금지를 변경하지 못했습니다",
         "world_collection_importing": "월드 컬렉션 가져오는 중 ({progress}/{total})",
         "game": "게임",
+        "game_stopped": "VRChat이(가) 실행되고 있지 않습니다.",
         "game_last_session": "마지막 세션",
         "servers": "서버",
         "servers_issue": "VRChat 서버에 문제가 발생했습니다",
+        "servers_ok": "VRChat 서버가 작동 중입니다.",
         "view_status": "서버 상태 보기",
         "proxy": "프록시",
         "realtime_connection": "실시간",
@@ -5892,16 +6004,14 @@
         "now_playing": "지금 재생 중",
         "instance_queue": "대기열",
         "instance_queue_waiting": "대기 중",
+        "instance_queue_position": "#{position}",
         "instance_queue_position_label": "위치",
+        "instance_queue_ready_to_join": "인스턴스가 {location}에 참여할 준비가 되었습니다.",
         "mutual_graph": "상호 그래프",
         "mutual_graph_fetching": "서로 친구를 불러오는 중",
         "mutual_graph_progress": "상호 그래프 가져오기 진행률",
         "start_background_mode": "배경 모드로 전환",
         "start_background_mode_tooltip": "배경 모드로 전환",
-        "game_stopped": "VRChat이(가) 실행되고 있지 않습니다.",
-        "servers_ok": "VRChat 서버가 작동 중입니다.",
-        "instance_queue_position": "#{position}",
-        "instance_queue_ready_to_join": "인스턴스가 {location}에 참여할 준비가 되었습니다.",
         "modify_proxy_address": "프록시 주소 수정",
         "proxy_disabled": "프록시 비활성화됨",
         "proxy_enabled_direct": "프록시 활성화됨, 직접 연결 중",
@@ -5938,6 +6048,11 @@
                 "failed_to_create_dashboard": "대시보드를 생성하지 못했습니다.",
                 "failed_to_update_dashboard": "대시보드를 업데이트하지 못했습니다.",
                 "failed_to_delete_dashboard": "대시보드를 삭제하지 못했습니다."
+            }
+        },
+        "region_code_badge": {
+            "dynamic": {
+                "region_value": "지역: {value}"
             }
         },
         "avatar_provider_settings": {
@@ -5980,10 +6095,10 @@
                 "failed_to_save_status_bar_visibility": "상태 표시줄 가시성을 저장하지 못했습니다.",
                 "failed_to_save_clock_count": "시계 수를 저장하지 못했습니다.",
                 "failed_to_save_status_bar_clocks": "상태 표시줄 시계를 저장하지 못했습니다.",
+                "failed_to_open_vrchat_status": "VRChat 상태를 열지 못했습니다.",
                 "failed_to_open_media_link": "미디어 링크를 열지 못했습니다.",
                 "failed_to_update_proxy_settings": "프록시 설정을 업데이트하지 못했습니다.",
-                "failed_to_start_background_mode": "백그라운드 모드로 전환하지 못했습니다.",
-                "failed_to_open_vrchat_status": "VRChat 상태를 열지 못했습니다."
+                "failed_to_start_background_mode": "백그라운드 모드로 전환하지 못했습니다."
             }
         },
         "location": {
@@ -6022,11 +6137,6 @@
                 "failed_to_launch_instance": "인스턴스를 시작하지 못했습니다.",
                 "failed_to_send_self_invite": "본인 초대를 보내지 못했습니다."
             }
-        },
-        "region_code_badge": {
-            "dynamic": {
-                "region_value": "지역: {value}"
-            }
         }
     },
     "host": {
@@ -6036,8 +6146,8 @@
                 "launch_action_failed": "실행 작업 실패"
             },
             "modal": {
-                "launch": "실행",
                 "launch_vrchat": "VRChat 실행",
+                "launch": "실행",
                 "vrchat_is_already_running_continue_launching_this_instance": "VRChat이 이미 실행 중입니다. VRCX-0이 실행 중인 클라이언트에 또 다른 실행 요청을 보냅니다. 여러 클라이언트가 열려 있는 경우 GameLog, 현재 위치, 플레이어 목록 및 일부 백그라운드 서비스가 불안정할 수 있습니다. 계속하시겠습니까?"
             },
             "dynamic": {
@@ -6048,11 +6158,11 @@
             "toast": {
                 "failed_to_load_launch_options": "시작 옵션을 로드하지 못했습니다.",
                 "failed_to_save_launch_options": "시작 옵션을 저장하지 못했습니다.",
+                "failed_to_load_vrchat_configuration": "VRChat 구성을 로드하지 못했습니다.",
                 "failed_to_select_folder": "폴더를 선택하지 못했습니다.",
+                "removed_value_cache_entries": "{value} 캐시 항목을 제거했습니다.",
                 "failed_to_sweep_asset_cache": "자산 캐시를 비우지 못했습니다.",
                 "failed_to_delete_asset_cache": "자산 캐시를 삭제하지 못했습니다.",
-                "failed_to_load_vrchat_configuration": "VRChat 구성을 로드하지 못했습니다.",
-                "removed_value_cache_entries": "{value} 캐시 항목을 제거했습니다.",
                 "failed_to_save_vrchat_configuration": "VRChat 구성을 저장하지 못했습니다."
             },
             "dynamic": {
@@ -6112,12 +6222,14 @@
         }
     },
     "service": {
+        "background_maintenance_service": {
+            "dynamic": {
+                "version_value_is_available_on_the_value_branch": "버전 {value}은(는) {value2} 분기에서 사용할 수 있습니다."
+            }
+        },
         "database_upgrade_service": {
             "label": {
                 "database_schema_is_current": "데이터베이스 스키마가 최신입니다."
-            },
-            "success": {
-                "database_update_complete": "데이터베이스 업데이트 완료"
             },
             "error": {
                 "failed_upgrade_description": "이전 데이터베이스 업그레이드가 실패했습니다. 이 데이터베이스는 수동으로 복구할 때까지 사용할 수 없습니다.",
@@ -6125,24 +6237,13 @@
                 "legacy_migration_restart_failed": "기존 VRCX 데이터를 마이그레이션하기 위한 VRCX-0 재시작에 실패했습니다. 다시 시도하거나 건너뛰고 현재 데이터베이스로 계속할 수 있습니다.",
                 "newer_schema_requires_newer_app": "이 데이터베이스의 스키마 버전은 {value}이지만 현재 VRCX-0은 {value2}까지만 지원합니다. 최신 버전의 VRCX-0을 설치한 후 다시 여세요."
             },
+            "success": {
+                "database_update_complete": "데이터베이스 업데이트 완료"
+            },
             "action": {
                 "refresh_config_failed_after_upgrade": "VRCX-0이(가) 데이터베이스를 업그레이드했지만 로컬 구성을 새로 고치지 못했습니다. 응용 프로그램을 다시 시작하십시오",
                 "requesting_legacy_migration": "기존 VRCX 데이터 마이그레이션을 준비하는 중입니다…",
                 "skipping_legacy_migration": "마이그레이션을 건너뛰고 데이터베이스를 초기화하는 중입니다…"
-            }
-        },
-        "background_maintenance": {
-            "label": {
-                "vrchat_registry_backup": "VRChat 레지스트리 백업",
-                "vrcx_update_available": "VRCX-0 업데이트 가능"
-            },
-            "description": {
-                "registry_backup_restore_description": "VRChat 레지스트리 폴더가 누락되었으며 저장된 레지스트리 백업을 사용할 수 있습니다. VRChat을 시작하기 전에 백업을 복원하세요."
-            }
-        },
-        "background_maintenance_service": {
-            "dynamic": {
-                "version_value_is_available_on_the_value_branch": "버전 {value}은(는) {value2} 분기에서 사용할 수 있습니다."
             }
         },
         "favorite_import_service": {
@@ -6161,19 +6262,28 @@
                 "unknown_tool_action_value": "알 수 없는 도구 작업: {value}",
                 "unsupported_tool_action_value": "지원되지 않는 도구 작업: {value}"
             }
+        },
+        "background_maintenance": {
+            "label": {
+                "vrchat_registry_backup": "VRChat 레지스트리 백업",
+                "vrcx_update_available": "VRCX-0 업데이트 가능"
+            },
+            "description": {
+                "registry_backup_restore_description": "VRChat 레지스트리 폴더가 누락되었으며 저장된 레지스트리 백업을 사용할 수 있습니다. VRChat을 시작하기 전에 백업을 복원하세요."
+            }
         }
     },
     "repository": {
         "sqlite_repository": {
             "modal": {
+                "please_repair_or_delete_your_database_file_by_fo": "VRCX-0 데이터베이스 복구 지침에 따라 데이터베이스 파일을 복구하거나 삭제하십시오.",
                 "your_database_is_corrupted": "데이터베이스가 손상되었습니다",
                 "disk_full_description": "데이터베이스가 포함된 디스크가 가득 찼습니다.",
                 "disk_full_title": "데이터베이스가 포함된 디스크가 가득 찼습니다.",
                 "database_locked_description": "데이터베이스 파일을 사용하고 있는 다른 응용 프로그램을 닫으세요.",
                 "database_locked_title": "데이터베이스가 잠겨 있습니다.",
                 "disk_io_error_description": "데이터베이스에 액세스하는 동안 디스크 I/O 오류가 발생했습니다.",
-                "disk_io_error_title": "디스크 I/O 오류",
-                "please_repair_or_delete_your_database_file_by_fo": "VRCX-0 데이터베이스 복구 지침에 따라 데이터베이스 파일을 복구하거나 삭제하십시오."
+                "disk_io_error_title": "디스크 I/O 오류"
             }
         }
     },
@@ -6219,6 +6329,8 @@
             "live_friend_location_board_for_finding_people": "사람을 찾기 위한 실시간 친구 위치 보드입니다.",
             "game_log": "게임 로그",
             "table_heavy_game_event_log": "테이블이 많은 게임 이벤트 로그.",
+            "instance_history": "인스턴스 기록",
+            "local_instance_history_for_a_selected_user": "선택한 사용자의 인스턴스 기록입니다.",
             "current_players": "현재 플레이어",
             "search": "검색",
             "world_and_group_search_route": "월드 및 그룹 검색 경로입니다.",
@@ -6252,12 +6364,12 @@
             "inventory_browser_and_media_actions": "인벤토리 브라우저 및 미디어 작업.",
             "screenshot_metadata": "스크린샷",
             "screenshot_metadata_browser_and_file_actions": "스크린샷 브라우저 및 파일 작업.",
+            "vrchat_log": "VRChat 로그 뷰어",
+            "vrchat_log_viewer_for_local_output_logs": "로컬 VRChat 출력 로그 뷰어.",
             "settings": "설정",
             "settings_and_diagnostics": "설정 및 진단.",
             "current_instance_player_roster_rebuilt_from_local_activity_data": "로컬 활동 데이터를 바탕으로 현재 인스턴스 플레이어 명단을 재구성했습니다.",
             "themes": "테마",
-            "vrchat_log": "VRChat 로그 뷰어",
-            "vrchat_log_viewer_for_local_output_logs": "로컬 VRChat 출력 로그 뷰어.",
             "themes_description": "테마 소스 및 사용자 정의 CSS 관리."
         }
     }


### PR DESCRIPTION
reordered ko.json translation keys from en.json to compare them easily
there are 61 keys that missing translations so I translated it (temp)
also removed `dialog.user.group_invite.description` key since it's not available on en.json